### PR TITLE
Prevent viewport debug command crash

### DIFF
--- a/debugConsole.go
+++ b/debugConsole.go
@@ -57,25 +57,26 @@ func debugConsole(resetCh, skipScene chan bool) {
 					fmt.Println("Unknown command", tokenString[1])
 				}
 			case "viewport":
-				switch tokenString[1] {
-				case "unlock":
-					if viewportLocked {
-						speed := parseTokenAsInt(tokenString, 2, 5)
-						viewportLocked = false
-						event.GlobalBind(moveViewportBinding(speed), "EnterFrame")
-					} else {
-						fmt.Println("Viewport is already unbound")
+				if len(tokenString) > 1 {
+					switch tokenString[1] {
+					case "unlock":
+						if viewportLocked {
+							speed := parseTokenAsInt(tokenString, 2, 5)
+							viewportLocked = false
+							event.GlobalBind(moveViewportBinding(speed), "EnterFrame")
+						} else {
+							fmt.Println("Viewport is already unbound")
+						}
+					case "lock":
+						if viewportLocked {
+							fmt.Println("Viewport is already locked")
+						} else {
+							viewportLocked = true
+						}
+					default:
+						fmt.Println("Unrecognized command for viewport")
 					}
-				case "lock":
-					if viewportLocked {
-						fmt.Println("Viewport is already locked")
-					} else {
-						viewportLocked = true
-					}
-				default:
-					fmt.Println("Unrecognized command for viewport")
 				}
-
 			case "fade":
 				if len(tokenString) > 1 {
 					toFade, ok := render.GetDebugRenderable(tokenString[1])


### PR DESCRIPTION
Small fix to prevent a crash when typing "viewport" in the console.

```...
[sceneLoop:45]  [Getting Transition Signal]
[sceneLoop:47]  [Resume Drawing]
[sceneLoop:51]  [Looping Scene]
viewport
panic: runtime error: index out of range

goroutine 8 [running]:
github.com/oakmound/oak.debugConsole(0xc42006c600, 0xc42006c4e0)
    /Users/deniscormier/go/src/github.com/oakmound/oak/debugConsole.go:60 +0x109b
created by github.com/oakmound/oak.Init
    /Users/deniscormier/go/src/github.com/oakmound/oak/init.go:120 +0x608```

Now, typing "viewport" does nothing (similar to other commands that expect an argument but receive none).