### PR TITLE
Release/1.0.3

### DIFF
--- a/config.go
+++ b/config.go
@@ -10,8 +10,8 @@ import (
 )
 
 var (
-	tmpConf oakConfig
-	conf    = oakConfig{
+	tmpConf Config
+	conf    = Config{
 		Assets{"assets/", "audio/", "images/", "font/"},
 		Debug{"", "ERROR"},
 		Screen{480, 640},
@@ -24,7 +24,8 @@ var (
 	}
 )
 
-type oakConfig struct {
+// Config stores initialization settings for oak.
+type Config struct {
 	Assets        Assets `json:"assets"`
 	Debug         Debug  `json:"debug"`
 	Screen        Screen `json:"screen"`
@@ -69,7 +70,7 @@ type Font struct {
 func LoadConf(fileName string) (err error) {
 	wd, err := os.Getwd()
 	if err != nil {
-		return err
+		return
 	}
 	dlog.Verb(conf)
 
@@ -77,7 +78,7 @@ func LoadConf(fileName string) (err error) {
 	return
 }
 
-func loadDefaultConf() {
+func initConf() {
 
 	if tmpConf.Assets.AssetPath != "" {
 		conf.Assets.AssetPath = tmpConf.Assets.AssetPath
@@ -143,33 +144,18 @@ func loadDefaultConf() {
 	dlog.Error(conf)
 }
 
-func loadOakConfig(fileName string) (oakConfig, error) {
+func loadOakConfig(fileName string) (Config, error) {
 
 	dlog.Error("Loading config:", fileName)
 
 	confFile, err := ioutil.ReadFile(fileName)
 	if err != nil {
 		dlog.Error(err)
-		return oakConfig{}, err
+		return Config{}, err
 	}
-	var config oakConfig
+	var config Config
 	err = json.Unmarshal(confFile, &config)
 	dlog.Error(config)
 
 	return config, err
-}
-
-func (oc *oakConfig) String() string {
-	st := "Config:\n{"
-	st += oc.Debug.String()
-	st += "\n}"
-	return st
-}
-
-func (d *Debug) String() string {
-	st := "Debug:\n{"
-	st += "Level: " + d.Level
-	st += "\nFilter:" + d.Filter
-	st += "\n}"
-	return st
 }

--- a/event/bind.go
+++ b/event/bind.go
@@ -1,8 +1,6 @@
 package event
 
-import (
-	"github.com/oakmound/oak/dlog"
-)
+import "github.com/oakmound/oak/dlog"
 
 // BindPriority is called by entities. Entities pass in a bindable function,
 // and a set of options which are parsed out.

--- a/event/eventBus.go
+++ b/event/eventBus.go
@@ -113,6 +113,8 @@ func (cid CID) String() string {
 }
 
 // E is shorthand for GetEntity(int(cid))
+// But we apparently forgot we added this shorthand,
+// because this isn't used anywhere.
 func (cid CID) E() interface{} {
 	return GetEntity(int(cid))
 }

--- a/init.go
+++ b/init.go
@@ -83,7 +83,7 @@ var (
 func Init(firstScene string) {
 	dlog.CreateLogFile()
 
-	loadDefaultConf()
+	initConf()
 
 	// Set variables from conf file
 	dlog.SetStringDebugLevel(conf.Debug.Level)

--- a/physics/attach.go
+++ b/physics/attach.go
@@ -31,14 +31,14 @@ func (v Vector) Attach(a Attachable, offsets ...float64) Vector {
 	return v3
 }
 
-// AttachX performs an attachement with a required x offset
+// AttachX performs an attachment that only attaches on the X axis.
 func (v Vector) AttachX(a Attachable, offX float64) Vector {
 	v2 := a.Vec()
 	v3 := Vector{v2.x, v.y, offX, 0}
 	return v3
 }
 
-// AttachY performs an attachement with a required y offset
+// AttachY performs an attachment that only attaches on the Y axis.
 func (v Vector) AttachY(a Attachable, offY float64) Vector {
 	v2 := a.Vec()
 	v3 := Vector{v.x, v2.y, 0, offY}

--- a/render/animation.go
+++ b/render/animation.go
@@ -22,6 +22,7 @@ func (sh *Sheet) SubSprite(x, y int) *Sprite {
 //Animation takes a set of frames and provides a framework for animating them
 type Animation struct {
 	LayeredPoint
+	pauseBool
 	sheetPos      int
 	frameTime     int64
 	frames        [][]int
@@ -142,16 +143,6 @@ func (a *Animation) Modify(ms ...Modification) Modifiable {
 		}
 	}
 	return a
-}
-
-//Pause stops the animation from animating
-func (a *Animation) Pause() {
-	a.playing = false
-}
-
-//Unpause restarts the animation from the animating
-func (a *Animation) Unpause() {
-	a.playing = true
 }
 
 // IsStatic returns false for animations

--- a/render/animation.go
+++ b/render/animation.go
@@ -92,7 +92,7 @@ func (a *Animation) SetTriggerID(id event.CID) {
 	a.cID = id
 }
 
-func (a *Animation) updateAnimation() {
+func (a *Animation) update() {
 	if a.playing && time.Since(a.lastChange).Nanoseconds() > a.frameTime {
 		a.lastChange = time.Now()
 		a.sheetPos = (a.sheetPos + 1) % len(a.frames)
@@ -108,14 +108,14 @@ func (a *Animation) updateAnimation() {
 
 //DrawOffset draws the animation with some x,y  offset from its logical location
 func (a *Animation) DrawOffset(buff draw.Image, xOff, yOff float64) {
-	a.updateAnimation()
+	a.update()
 	img := a.GetRGBA()
 	ShinyDraw(buff, img, int(a.X()+xOff), int(a.Y()+yOff))
 }
 
 //Draw draws the animation at its logical location
 func (a *Animation) Draw(buff draw.Image) {
-	a.updateAnimation()
+	a.update()
 	img := a.GetRGBA()
 	ShinyDraw(buff, img, int(a.X()), int(a.Y()))
 }
@@ -152,4 +152,9 @@ func (a *Animation) Pause() {
 //Unpause restarts the animation from the animating
 func (a *Animation) Unpause() {
 	a.playing = true
+}
+
+// IsStatic returns false for animations
+func (a *Animation) IsStatic() bool {
+	return false
 }

--- a/render/compound.go
+++ b/render/compound.go
@@ -20,7 +20,7 @@ type Compound struct {
 	curRenderable  string
 }
 
-//NewCompound creates a new compound from a map of names to modifiables
+// NewCompound creates a new compound from a map of names to modifiables
 func NewCompound(start string, m map[string]Modifiable) *Compound {
 	return &Compound{
 		LayeredPoint:   NewLayeredPoint(0, 0, 0),
@@ -29,65 +29,38 @@ func NewCompound(start string, m map[string]Modifiable) *Compound {
 	}
 }
 
-//Add makes a new entry in the Compounds map
+// Add makes a new entry in the Compounds map
 func (c *Compound) Add(k string, v Modifiable) {
 	c.subRenderables[k] = v
 }
 
-//Set sets the current renderable to the one specified
+// Set sets the current renderable to the one specified
 func (c *Compound) Set(k string) {
 	if _, ok := c.subRenderables[k]; !ok {
+		// Todo: return an error here, don't panic
 		panic("Unknown renderable for string " + k + " on compound")
 	}
 	c.curRenderable = k
 }
 
-//GetSub returns a given subrenderable from the map
+// GetSub returns a keyed Modifiable from this compound's map
 func (c *Compound) GetSub(s string) Modifiable {
 	return c.subRenderables[s]
 }
 
-//Get returns the Compounds current Renderable
+// Get returns the Compound's current key
 func (c *Compound) Get() string {
 	return c.curRenderable
 }
 
-//IsInterruptable returns whether the current renderable is interruptable
-func (c *Compound) IsInterruptable() bool {
-	switch t := c.subRenderables[c.curRenderable].(type) {
-	case *Animation:
-		return t.Interruptable
-	case *Sequence:
-		return t.Interruptable
-	case *Reverting:
-		return t.IsInterruptable()
-	case *Compound:
-		return t.IsInterruptable()
-	}
-	return true
-}
-
-//IsStatic returns whether the current renderable is static
-func (c *Compound) IsStatic() bool {
-	switch c.subRenderables[c.curRenderable].(type) {
-	case *Animation, *Sequence:
-		return false
-	case *Reverting:
-		return c.subRenderables[c.curRenderable].(*Reverting).IsStatic()
-	case *Compound:
-		return c.subRenderables[c.curRenderable].(*Compound).IsStatic()
-	}
-	return true
-}
-
-//SetOffsets sets the logical offset for the specified subrenderable
+// SetOffsets sets the logical offset for the specified key
 func (c *Compound) SetOffsets(k string, offsets physics.Vector) {
 	if r, ok := c.subRenderables[k]; ok {
 		r.SetPos(offsets.X(), offsets.Y())
 	}
 }
 
-//Copy creates a copy of the Compound
+// Copy creates a copy of the Compound
 func (c *Compound) Copy() Modifiable {
 	newC := new(Compound)
 	newC.LayeredPoint = c.LayeredPoint.Copy()
@@ -105,7 +78,7 @@ func (c *Compound) GetRGBA() *image.RGBA {
 	return c.subRenderables[c.curRenderable].GetRGBA()
 }
 
-//Modify performs a series of modifications on the Compound
+// Modify performs a series of modifications on the Compound
 func (c *Compound) Modify(ms ...Modification) Modifiable {
 	for _, r := range c.subRenderables {
 		r.Modify(ms...)
@@ -123,56 +96,62 @@ func (c *Compound) Draw(buff draw.Image) {
 	c.subRenderables[c.curRenderable].DrawOffset(buff, c.X(), c.Y())
 }
 
-//ShiftPos shifts the Compounds logical position
+// ShiftPos shifts the Compounds logical position
 func (c *Compound) ShiftPos(x, y float64) {
 	c.SetPos(c.X()+x, c.Y()+y)
 }
 
-//ShiftY shifts the Compounds logical y position
+// ShiftY shifts the Compounds logical y position
 func (c *Compound) ShiftY(y float64) {
 	c.SetPos(c.X(), c.Y()+y)
 }
 
-//ShiftX shifts the Compounds logical x position
+// ShiftX shifts the Compounds logical x position
 func (c *Compound) ShiftX(x float64) {
 	c.SetPos(c.X()+x, c.Y())
 }
 
-//SetPos sets the Compound's logical position
+// SetPos sets the Compound's logical position
 func (c *Compound) SetPos(x, y float64) {
 	c.LayeredPoint.SetPos(x, y)
 }
 
-//GetDims gets the current Renderables dimensions
+// GetDims gets the current Renderables dimensions
 func (c *Compound) GetDims() (int, int) {
 	return c.subRenderables[c.curRenderable].GetDims()
 }
 
-//Pause stops the current Renderable if possible
+// Pause stops the current Renderable if possible
 func (c *Compound) Pause() {
-	switch t := c.subRenderables[c.curRenderable].(type) {
-	case *Animation:
-		t.Pause()
-	case *Sequence:
-		t.Pause()
-	case *Reverting:
-		t.Pause()
+	if cp, ok := c.subRenderables[c.curRenderable].(CanPause); ok {
+		cp.Pause()
 	}
 }
 
 // Unpause tries to unpause the current Renderable if possible
 func (c *Compound) Unpause() {
-	switch t := c.subRenderables[c.curRenderable].(type) {
-	case *Animation:
-		t.Unpause()
-	case *Sequence:
-		t.Unpause()
-	case *Reverting:
-		t.Unpause()
+	if cp, ok := c.subRenderables[c.curRenderable].(CanPause); ok {
+		cp.Unpause()
 	}
 }
 
-//Revert tries to revert the current Renderable if possible
+// IsInterruptable returns whether the current renderable is interruptable
+func (c *Compound) IsInterruptable() bool {
+	if i, ok := c.subRenderables[c.curRenderable].(NonInterruptable); ok {
+		return i.IsInterruptable()
+	}
+	return true
+}
+
+// IsStatic returns whether the current renderable is static
+func (c *Compound) IsStatic() bool {
+	if s, ok := c.subRenderables[c.curRenderable].(NonStatic); ok {
+		return s.IsStatic()
+	}
+	return true
+}
+
+// Revert will revert all parts of this compound that can be reverted
 func (c *Compound) Revert(mod int) {
 	for _, v := range c.subRenderables {
 		switch t := v.(type) {
@@ -182,7 +161,8 @@ func (c *Compound) Revert(mod int) {
 	}
 }
 
-//RevertAll tries to revert the all sub-Renderables if possible
+// RevertAll will revert all parts of this compound that can be reverted, back
+// to their original state.
 func (c *Compound) RevertAll() {
 	for _, v := range c.subRenderables {
 		switch t := v.(type) {

--- a/render/compound.go
+++ b/render/compound.go
@@ -3,6 +3,7 @@ package render
 import (
 	"image"
 	"image/draw"
+	"sync"
 
 	"github.com/oakmound/oak/physics"
 )
@@ -18,6 +19,7 @@ type Compound struct {
 	LayeredPoint
 	subRenderables map[string]Modifiable
 	curRenderable  string
+	lock           sync.RWMutex
 }
 
 // NewCompound creates a new compound from a map of names to modifiables
@@ -26,26 +28,34 @@ func NewCompound(start string, m map[string]Modifiable) *Compound {
 		LayeredPoint:   NewLayeredPoint(0, 0, 0),
 		subRenderables: m,
 		curRenderable:  start,
+		lock:           sync.RWMutex{},
 	}
 }
 
 // Add makes a new entry in the Compounds map
 func (c *Compound) Add(k string, v Modifiable) {
+	c.lock.Lock()
 	c.subRenderables[k] = v
+	c.lock.Unlock()
 }
 
 // Set sets the current renderable to the one specified
 func (c *Compound) Set(k string) {
+	c.lock.RLock()
 	if _, ok := c.subRenderables[k]; !ok {
 		// Todo: return an error here, don't panic
 		panic("Unknown renderable for string " + k + " on compound")
 	}
+	c.lock.RUnlock()
 	c.curRenderable = k
 }
 
 // GetSub returns a keyed Modifiable from this compound's map
 func (c *Compound) GetSub(s string) Modifiable {
-	return c.subRenderables[s]
+	c.lock.RLock()
+	m := c.subRenderables[s]
+	c.lock.RUnlock()
+	return m
 }
 
 // Get returns the Compound's current key
@@ -55,9 +65,11 @@ func (c *Compound) Get() string {
 
 // SetOffsets sets the logical offset for the specified key
 func (c *Compound) SetOffsets(k string, offsets physics.Vector) {
+	c.lock.RLock()
 	if r, ok := c.subRenderables[k]; ok {
 		r.SetPos(offsets.X(), offsets.Y())
 	}
+	c.lock.RUnlock()
 }
 
 // Copy creates a copy of the Compound
@@ -65,35 +77,47 @@ func (c *Compound) Copy() Modifiable {
 	newC := new(Compound)
 	newC.LayeredPoint = c.LayeredPoint.Copy()
 	newSubRenderables := make(map[string]Modifiable)
+	c.lock.RLock()
 	for k, v := range c.subRenderables {
 		newSubRenderables[k] = v.Copy()
 	}
+	c.lock.RUnlock()
 	newC.subRenderables = newSubRenderables
 	newC.curRenderable = c.curRenderable
+	newC.lock = sync.RWMutex{}
 	return newC
 }
 
 //GetRGBA returns the current renderables rgba
 func (c *Compound) GetRGBA() *image.RGBA {
-	return c.subRenderables[c.curRenderable].GetRGBA()
+	c.lock.RLock()
+	rgba := c.subRenderables[c.curRenderable].GetRGBA()
+	c.lock.RUnlock()
+	return rgba
 }
 
 // Modify performs a series of modifications on the Compound
 func (c *Compound) Modify(ms ...Modification) Modifiable {
+	c.lock.RLock()
 	for _, r := range c.subRenderables {
 		r.Modify(ms...)
 	}
+	c.lock.RUnlock()
 	return c
 }
 
 //DrawOffset draws the Compound at an offset from its logical location
 func (c *Compound) DrawOffset(buff draw.Image, xOff float64, yOff float64) {
+	c.lock.RLock()
 	c.subRenderables[c.curRenderable].DrawOffset(buff, c.X()+xOff, c.Y()+yOff)
+	c.lock.RUnlock()
 }
 
 //Draw draws the Compound at its logical location
 func (c *Compound) Draw(buff draw.Image) {
+	c.lock.RLock()
 	c.subRenderables[c.curRenderable].DrawOffset(buff, c.X(), c.Y())
+	c.lock.RUnlock()
 }
 
 // ShiftPos shifts the Compounds logical position
@@ -118,25 +142,34 @@ func (c *Compound) SetPos(x, y float64) {
 
 // GetDims gets the current Renderables dimensions
 func (c *Compound) GetDims() (int, int) {
-	return c.subRenderables[c.curRenderable].GetDims()
+	c.lock.RLock()
+	w, h := c.subRenderables[c.curRenderable].GetDims()
+	c.lock.RUnlock()
+	return w, h
 }
 
 // Pause stops the current Renderable if possible
 func (c *Compound) Pause() {
+	c.lock.RLock()
 	if cp, ok := c.subRenderables[c.curRenderable].(CanPause); ok {
 		cp.Pause()
 	}
+	c.lock.RUnlock()
 }
 
 // Unpause tries to unpause the current Renderable if possible
 func (c *Compound) Unpause() {
+	c.lock.RLock()
 	if cp, ok := c.subRenderables[c.curRenderable].(CanPause); ok {
 		cp.Unpause()
 	}
+	c.lock.RUnlock()
 }
 
 // IsInterruptable returns whether the current renderable is interruptable
 func (c *Compound) IsInterruptable() bool {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
 	if i, ok := c.subRenderables[c.curRenderable].(NonInterruptable); ok {
 		return i.IsInterruptable()
 	}
@@ -145,6 +178,8 @@ func (c *Compound) IsInterruptable() bool {
 
 // IsStatic returns whether the current renderable is static
 func (c *Compound) IsStatic() bool {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
 	if s, ok := c.subRenderables[c.curRenderable].(NonStatic); ok {
 		return s.IsStatic()
 	}
@@ -153,21 +188,25 @@ func (c *Compound) IsStatic() bool {
 
 // Revert will revert all parts of this compound that can be reverted
 func (c *Compound) Revert(mod int) {
+	c.lock.RLock()
 	for _, v := range c.subRenderables {
 		switch t := v.(type) {
 		case *Reverting:
 			t.Revert(mod)
 		}
 	}
+	c.lock.RUnlock()
 }
 
 // RevertAll will revert all parts of this compound that can be reverted, back
 // to their original state.
 func (c *Compound) RevertAll() {
+	c.lock.RLock()
 	for _, v := range c.subRenderables {
 		switch t := v.(type) {
 		case *Reverting:
 			t.RevertAll()
 		}
 	}
+	c.lock.RUnlock()
 }

--- a/render/compound.go
+++ b/render/compound.go
@@ -1,6 +1,7 @@
 package render
 
 import (
+	"errors"
 	"image"
 	"image/draw"
 	"sync"
@@ -40,14 +41,14 @@ func (c *Compound) Add(k string, v Modifiable) {
 }
 
 // Set sets the current renderable to the one specified
-func (c *Compound) Set(k string) {
+func (c *Compound) Set(k string) error {
 	c.lock.RLock()
 	if _, ok := c.subRenderables[k]; !ok {
-		// Todo: return an error here, don't panic
-		panic("Unknown renderable for string " + k + " on compound")
+		return errors.New("Unknown renderable for string " + k + " on compound")
 	}
 	c.lock.RUnlock()
 	c.curRenderable = k
+	return nil
 }
 
 // GetSub returns a keyed Modifiable from this compound's map

--- a/render/gradientbox.go
+++ b/render/gradientbox.go
@@ -10,15 +10,15 @@ type progressFunction func(x, y, w, h int) float64
 
 // Progress functions
 var (
-	//HorizontalProgress is a function to keep track of fractional progress across an object with progress x on width w
+	//HorizontalProgress measures progress as x / w
 	HorizontalProgress = func(x, y, w, h int) float64 {
 		return float64(x) / float64(w)
 	}
-	//VerticalProgress is a function to keep track of fractional progress across an object with progress y on height h
+	//VerticalProgress measures progress as y / h
 	VerticalProgress = func(x, y, w, h int) float64 {
 		return float64(y) / float64(h)
 	}
-	//CircularProgress is a functino to obtain a single progress metric given some distance x, y out from an objects origin with w, h diameters
+	//CircularProgress measures progress as distance from the center of a circle.
 	CircularProgress = func(x, y, w, h int) float64 {
 		xRadius := float64(w) / 2
 		yRadius := float64(h) / 2
@@ -56,17 +56,20 @@ func NewGradientBox(w, h int, startColor, endColor color.Color, pFunction progre
 	return NewSprite(0, 0, rgba)
 }
 
-// NewHorizontalGradientBox passes HorizontalProgress into NewGradientBox
+// NewHorizontalGradientBox returns a gradient box with a horizontal gradient from
+// the start to end color, left to right.
 func NewHorizontalGradientBox(w, h int, startColor, endColor color.Color) *Sprite {
 	return NewGradientBox(w, h, startColor, endColor, HorizontalProgress)
 }
 
-// NewVerticalGradientBox passes VerticalProgress into NewGradientBox
+// NewVerticalGradientBox returns a gradient box with a vertical gradient from
+// the start to end color, top to bottom.
 func NewVerticalGradientBox(w, h int, startColor, endColor color.Color) *Sprite {
 	return NewGradientBox(w, h, startColor, endColor, VerticalProgress)
 }
 
-// NewCircularGradientBox passes CircularProgress into NewGradientBox
+// NewCircularGradientBox returns a gradient box where the center will be startColor
+// and the gradient will radiate as a circle out from the center.
 func NewCircularGradientBox(w, h int, startColor, endColor color.Color) *Sprite {
 	return NewGradientBox(w, h, startColor, endColor, CircularProgress)
 }

--- a/render/interfaceFeatures.go
+++ b/render/interfaceFeatures.go
@@ -6,6 +6,18 @@ type CanPause interface {
 	Unpause()
 }
 
+type pauseBool struct {
+	playing bool
+}
+
+func (p *pauseBool) Pause() {
+	p.playing = false
+}
+
+func (p *pauseBool) Unpause() {
+	p.playing = true
+}
+
 // NonStatic types are not always static. If something is not NonStatic,
 // it is equivalent to having IsStatic always return true.
 type NonStatic interface {

--- a/render/interfaceFeatures.go
+++ b/render/interfaceFeatures.go
@@ -1,23 +1,5 @@
 package render
 
-// CanPause types have pause functions to start and stop animation
-type CanPause interface {
-	Pause()
-	Unpause()
-}
-
-type pauseBool struct {
-	playing bool
-}
-
-func (p *pauseBool) Pause() {
-	p.playing = false
-}
-
-func (p *pauseBool) Unpause() {
-	p.playing = true
-}
-
 // NonStatic types are not always static. If something is not NonStatic,
 // it is equivalent to having IsStatic always return true.
 type NonStatic interface {

--- a/render/interfaceFeatures.go
+++ b/render/interfaceFeatures.go
@@ -1,0 +1,24 @@
+package render
+
+// CanPause types have pause functions to start and stop animation
+type CanPause interface {
+	Pause()
+	Unpause()
+}
+
+// NonStatic types are not always static. If something is not NonStatic,
+// it is equivalent to having IsStatic always return true.
+type NonStatic interface {
+	IsStatic() bool
+}
+
+// NonInterruptable types are not always interruptable.  If something is not
+// NonInterruptable, it is equivalent to having IsInterruptable always return
+// true.
+type NonInterruptable interface {
+	IsInterruptable() bool
+}
+
+type updates interface {
+	update()
+}

--- a/render/layered.go
+++ b/render/layered.go
@@ -48,7 +48,8 @@ func NewLayeredPoint(x, y float64, l int) LayeredPoint {
 	}
 }
 
-// GetLayer returns the layer of an object if it has one or else returns that the object needs to be undrawn as it does not have a layer
+// GetLayer returns the layer of this point. If this is nil,
+// it will return Undraw
 func (ldp *LayeredPoint) GetLayer() int {
 	if ldp == nil {
 		return Undraw

--- a/render/layered.go
+++ b/render/layered.go
@@ -65,6 +65,9 @@ func (ldp *LayeredPoint) Copy() LayeredPoint {
 	return ldp2
 }
 
+// These functions are redefined because vector's internal
+// functions return Vectors, and we don't want to return Vectors.
+
 // ShiftX moves the LayeredPoint by the given x
 func (ldp *LayeredPoint) ShiftX(x float64) {
 	ldp.Vector.ShiftX(x)

--- a/render/line.go
+++ b/render/line.go
@@ -25,6 +25,7 @@ func NewThickLine(x1, y1, x2, y2 float64, c color.Color, thickness int) *Sprite 
 }
 
 // DrawLineOnto draws a line onto an image rgba from one point to another
+// Todo: this and drawLineBetween should be combined to reduce duplicate code
 func DrawLineOnto(rgba *image.RGBA, x1, y1, x2, y2 int, c color.Color) {
 
 	xDelta := math.Abs(float64(x2 - x1))
@@ -84,6 +85,7 @@ func drawLineBetween(x1, y1, x2, y2 int, c color.Color, th int) *image.RGBA {
 		xSlope = 1
 	}
 	ySlope := -1
+	// Todo: document why we add one here
 	h := int(yDelta) + 1
 	if y2 < y1 {
 		ySlope = 1

--- a/render/line.go
+++ b/render/line.go
@@ -100,9 +100,8 @@ func drawLineBetween(x1, y1, x2, y2 int, c color.Color, th int) *image.RGBA {
 	var err2 float64
 	for i := 0; true; i++ {
 
-		rgba.Set(x2, y2, c)
-		for xm := x2 - th; xm < (x2 + th); xm++ {
-			for ym := y2 - th; ym < (y2 + th); ym++ {
+		for xm := x2 - th; xm <= (x2 + th); xm++ {
+			for ym := y2 - th; ym <= (y2 + th); ym++ {
 				rgba.Set(xm, ym, c)
 			}
 		}

--- a/render/line_test.go
+++ b/render/line_test.go
@@ -1,0 +1,60 @@
+package render
+
+import (
+	"image"
+	"image/color"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLine(t *testing.T) {
+	l := NewLine(0, 0, 10, 10, color.RGBA{255, 255, 255, 255})
+	rgba := l.GetRGBA()
+	for x := 0; x < 10; x++ {
+		for y := 0; y < 10; y++ {
+			if x == y {
+				assert.Equal(t, rgba.At(x, y), color.RGBA{255, 255, 255, 255})
+			} else {
+				assert.Equal(t, rgba.At(x, y), color.RGBA{0, 0, 0, 0})
+			}
+		}
+	}
+	l = NewLine(0, 0, 0, 0, color.RGBA{255, 255, 255, 255})
+	rgba = l.GetRGBA()
+	rgba2 := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	rgba2.Set(0, 0, color.RGBA{255, 255, 255, 255})
+	assert.Equal(t, rgba, rgba2)
+
+	l = NewLine(0, 0, 0, 5, color.RGBA{255, 255, 255, 255})
+	rgba = l.GetRGBA()
+	rgba2 = image.NewRGBA(image.Rect(0, 0, 1, 5))
+	for y := 0; y < 5; y++ {
+		rgba2.Set(0, y, color.RGBA{255, 255, 255, 255})
+	}
+	assert.Equal(t, rgba, rgba2)
+}
+
+func TestThickLine(t *testing.T) {
+	l := NewThickLine(0, 0, 10, 10, color.RGBA{255, 255, 255, 255}, 1)
+	rgba := l.GetRGBA()
+	for x := 0; x < 10; x++ {
+		for y := 0; y < 10; y++ {
+			if math.Abs(float64(x)-float64(y)) <= 2 {
+				assert.Equal(t, rgba.At(x, y), color.RGBA{255, 255, 255, 255})
+			} else {
+				assert.Equal(t, rgba.At(x, y), color.RGBA{0, 0, 0, 0})
+			}
+		}
+	}
+}
+
+func TestDrawLineOnto(t *testing.T) {
+	l := NewLine(0, 0, 10, 10, color.RGBA{255, 255, 255, 255})
+	rgba := l.GetRGBA()
+	// See height addition in line
+	rgba2 := image.NewRGBA(image.Rect(0, 0, 10, 11))
+	DrawLineOnto(rgba2, 0, 0, 10, 10, color.RGBA{255, 255, 255, 255})
+	assert.Equal(t, rgba, rgba2)
+}

--- a/render/loader.go
+++ b/render/loader.go
@@ -161,7 +161,7 @@ func LoadSheetAnimation(fileName string, w, h, pad int, fps float64, frames []in
 }
 
 // LoadAnimation takes in a sheet with sheet dimensions, a frame rate and a list of frames where
-// frames are in x,y pairs ([0,0,1,0,2,0] for (0,0) (1,0) (2,0), and returns an animation from that
+// frames are in x,y pairs ([0,0,1,0,2,0] for (0,0) (1,0) (2,0)) and returns an animation from that
 func LoadAnimation(sheet *Sheet, w, h, pad int, fps float64, frames []int) (*Animation, error) {
 	animation, err := NewAnimation(sheet, fps, frames)
 	if err != nil {
@@ -183,10 +183,10 @@ func subImage(rgba *image.RGBA, x, y, w, h int) *image.RGBA {
 // BatchLoad loads subdirectories from the given base folder and imports all files,
 // using alias rules to automatically determine the size of sprites and sheets in
 // subfolders.
-// A folder named 16x16 will have its images split into sheets where each sprite is
-// 16x16, for example. Same forr 16x8. 16 is a shorter way of writing 16x16.
+// A folder named 16x8 will have its images split into sheets where each sprite is
+// 16x8, for example. 16 is a shorter way of writing 16x16.
 // An alias.json file can be included that can indicate what dimensions named folders
-// represent, so a tiles: "32x32" field in the json would indicate that sprite sheets
+// represent, so a "tiles": "32" field in the json would indicate that sprite sheets
 // in the /tiles folder should be read as 32x32
 func BatchLoad(baseFolder string) error {
 

--- a/render/logicfps.go
+++ b/render/logicfps.go
@@ -9,7 +9,7 @@ import (
 	"github.com/oakmound/oak/timing"
 )
 
-// LogicFPS is a draw stack element that will draw the fps onto the screen
+// LogicFPS is a draw stack element that will draw the logical fps onto the screen
 type LogicFPS struct {
 	event.CID
 	fps      int

--- a/render/modify.go
+++ b/render/modify.go
@@ -154,8 +154,8 @@ func pointBetween(p1, p2 point, f float64) point {
 func CutRel(relWidth, relHeight float64) Modification {
 	return func(rgba image.Image) *image.RGBA {
 		bds := rgba.Bounds()
-		newWidth := int(float64(bds.Max.X) * relWidth)
-		newHeight := int(float64(bds.Max.Y) * relHeight)
+		newWidth := alg.RoundF64(float64(bds.Max.X) * relWidth)
+		newHeight := alg.RoundF64(float64(bds.Max.Y) * relHeight)
 		newRgba := image.NewRGBA(image.Rect(0, 0, newWidth, newHeight))
 		for x := 0; x < newWidth; x++ {
 			for y := 0; y < newHeight; y++ {

--- a/render/modify.go
+++ b/render/modify.go
@@ -80,6 +80,7 @@ func FlipY(rgba *image.RGBA) *image.RGBA {
 	return newRgba
 }
 
+// todo: this should not be in this package
 type point struct {
 	X, Y float64
 }

--- a/render/particle/allocator.go
+++ b/render/particle/allocator.go
@@ -63,7 +63,7 @@ func Deallocate(block int) {
 	freeCh <- block
 }
 
-// LookupSource requests the source bound to a id in a block in the particle space
+// LookupSource requests the source that generated a pid
 func LookupSource(id int) *Source {
 	requestCh <- id
 	owner := <-responseCh

--- a/render/particle/colorParticle.go
+++ b/render/particle/colorParticle.go
@@ -31,6 +31,17 @@ func (cp *ColorParticle) DrawOffset(buff draw.Image, xOff, yOff float64) {
 func (cp *ColorParticle) DrawOffsetGen(generator Generator, buff draw.Image, xOff, yOff float64) {
 	gen := generator.(*ColorGenerator)
 
+	// Hmm. this is expensive.
+	// This work should be done by the Source because if the draw rate is faster
+	// than the enter frame rate than this is doing duplicate work
+	// does that mean every particle is the same struct (
+	//	baseParticle + image
+	//)
+	// and different particle types are just different update functions?
+	// -No- because we still need to keep track of variable things on these particles
+	// but it -does- mean that particles should track an image that they all have a function
+	// to create instead of these Draw functions which should just be provided by
+	// baseParticle
 	r, g, b, a := cp.startColor.RGBA()
 	r2, g2, b2, a2 := cp.endColor.RGBA()
 	progress := cp.Life / cp.totalLife

--- a/render/pausing.go
+++ b/render/pausing.go
@@ -1,0 +1,19 @@
+package render
+
+// CanPause types have pause functions to start and stop animation
+type CanPause interface {
+	Pause()
+	Unpause()
+}
+
+type pauseBool struct {
+	playing bool
+}
+
+func (p *pauseBool) Pause() {
+	p.playing = false
+}
+
+func (p *pauseBool) Unpause() {
+	p.playing = true
+}

--- a/render/polygon.go
+++ b/render/polygon.go
@@ -152,7 +152,8 @@ func BoundingRect(points []physics.Vector) (MinX, MinY, MaxX, MaxY float64, w, h
 	return
 }
 
-// Contains Returns whether or not the current Polygon contains the passed in Point.
+// Contains returns whether or not the current Polygon contains the passed in Point.
+// It is the default containment function, versus wrapping and convex.
 func (pg *Polygon) Contains(x, y float64) (contains bool) {
 
 	if x < pg.MinX || x > pg.MaxX || y < pg.MinY || y > pg.MaxY {
@@ -198,7 +199,7 @@ func (pg *Polygon) WrappingContains(x, y float64) bool {
 }
 
 // ConvexContains returns whether the given point is contained by the input polygon.
-// It assumes the polygon is convex.
+// It assumes the polygon is convex. It outperforms the alternatives.
 func (pg *Polygon) ConvexContains(x, y float64) bool {
 
 	if x < pg.MinX || x > pg.MaxX || y < pg.MinY || y > pg.MaxY {

--- a/render/renderable.go
+++ b/render/renderable.go
@@ -30,6 +30,7 @@ type Renderable interface {
 	// consequences.
 	Draw(buff draw.Image)
 	DrawOffset(buff draw.Image, xOff, yOff float64)
+
 	// Basic Implementing struct: Point
 	ShiftX(x float64)
 	GetX() float64
@@ -47,5 +48,6 @@ type Renderable interface {
 	String() string
 
 	// Physics
+	// Basic Implementing struct: physics.Vector
 	physics.Attachable
 }

--- a/render/reverting.go
+++ b/render/reverting.go
@@ -16,36 +16,7 @@ func NewReverting(m Modifiable) *Reverting {
 	return rv
 }
 
-// IsInterruptable returns if the underlying Modifiable for this reverting is interruptable.
-func (rv *Reverting) IsInterruptable() bool {
-	switch t := rv.rs[0].(type) {
-	case *Animation:
-		return t.Interruptable
-	case *Sequence:
-		return t.Interruptable
-	case *Reverting:
-		return t.IsInterruptable()
-	case *Compound:
-		return t.IsInterruptable()
-	}
-	return true
-}
-
-// IsStatic returns if the underlying Modifiable for this reverting is static.
-func (rv *Reverting) IsStatic() bool {
-	switch t := rv.rs[0].(type) {
-	case *Animation, *Sequence:
-		return false
-	case *Reverting:
-		return t.IsStatic()
-	case *Compound:
-		return t.IsStatic()
-	}
-	return true
-}
-
-// Revert goes back n steps in this Reverting's history and displays that
-// Modifiable
+// Revert goes back n steps in this Reverting's history and displays that Modifiable
 func (rv *Reverting) Revert(n int) {
 	x := rv.GetX()
 	y := rv.GetY()
@@ -94,7 +65,7 @@ func (rv *Reverting) Modify(ms ...Modification) Modifiable {
 	return rv
 }
 
-// Copy returns a copy of the Reverting
+// Copy returns a copy of this Reverting
 func (rv *Reverting) Copy() Modifiable {
 	newRv := new(Reverting)
 	newRv.rs = make([]Modifiable, len(rv.rs))
@@ -105,22 +76,55 @@ func (rv *Reverting) Copy() Modifiable {
 	return newRv
 }
 
-func (rv *Reverting) updateAnimation() {
-	switch t := rv.Modifiable.(type) {
-	case *Animation:
-		t.updateAnimation()
-	case *Sequence:
-		t.update()
+// This might not ever be called?
+func (rv *Reverting) update() {
+	if u, ok := rv.Modifiable.(updates); ok {
+		u.update()
 	}
-	switch t := rv.rs[0].(type) {
-	case *Animation:
-		t.updateAnimation()
-	case *Sequence:
-		t.update()
+	if u, ok := rv.rs[0].(updates); ok {
+		u.update()
 	}
 }
 
+// Pause ceases animating any renderable types that animate underneath this
+func (rv *Reverting) Pause() {
+	if cp, ok := rv.Modifiable.(CanPause); ok {
+		cp.Pause()
+	}
+	if cp, ok := rv.rs[0].(CanPause); ok {
+		cp.Pause()
+	}
+}
+
+// Unpause resumes animating any renderable types that animate underneath this
+func (rv *Reverting) Unpause() {
+	if cp, ok := rv.Modifiable.(CanPause); ok {
+		cp.Unpause()
+	}
+	if cp, ok := rv.rs[0].(CanPause); ok {
+		cp.Unpause()
+	}
+}
+
+// IsInterruptable returns if whatever this reverting is currently dispalying is interruptable.
+func (rv *Reverting) IsInterruptable() bool {
+	if i, ok := rv.rs[0].(NonInterruptable); ok {
+		return i.IsInterruptable()
+	}
+	return true
+}
+
+// IsInterruptable returns if whatever this reverting is currently dispalying is static.
+func (rv *Reverting) IsStatic() bool {
+	if s, ok := rv.rs[0].(NonStatic); ok {
+		return s.IsStatic()
+	}
+	return true
+}
+
 // Set calls Set on underlying types below this Reverting that cat be Set
+// Todo: if Set becomes used by more types, this should use an interface like
+// CanPause
 func (rv *Reverting) Set(k string) {
 	switch t := rv.Modifiable.(type) {
 	case *Compound:
@@ -129,46 +133,5 @@ func (rv *Reverting) Set(k string) {
 	switch t := rv.rs[0].(type) {
 	case *Compound:
 		t.Set(k)
-	}
-}
-
-// Pause ceases animating any renderable types that animate underneath this
-func (rv *Reverting) Pause() {
-	switch t := rv.Modifiable.(type) {
-	case *Animation:
-		t.playing = false
-	case *Compound:
-		t.Pause()
-	case *Sequence:
-		t.Pause()
-	}
-	switch t := rv.rs[0].(type) {
-	case *Animation:
-		t.playing = false
-	case *Compound:
-		t.Pause()
-	case *Sequence:
-		t.Pause()
-	}
-
-}
-
-// Unpause resumes animating any renderable types that animate underneath this
-func (rv *Reverting) Unpause() {
-	switch t := rv.Modifiable.(type) {
-	case *Animation:
-		t.playing = true
-	case *Compound:
-		t.Unpause()
-	case *Sequence:
-		t.Unpause()
-	}
-	switch t := rv.rs[0].(type) {
-	case *Animation:
-		t.playing = true
-	case *Compound:
-		t.Unpause()
-	case *Sequence:
-		t.Unpause()
 	}
 }

--- a/render/reverting.go
+++ b/render/reverting.go
@@ -114,7 +114,7 @@ func (rv *Reverting) IsInterruptable() bool {
 	return true
 }
 
-// IsInterruptable returns if whatever this reverting is currently dispalying is static.
+// IsStatic returns if whatever this reverting is currently displaying is static.
 func (rv *Reverting) IsStatic() bool {
 	if s, ok := rv.rs[0].(NonStatic); ok {
 		return s.IsStatic()

--- a/render/scrollbox.go
+++ b/render/scrollbox.go
@@ -52,10 +52,10 @@ func (s *ScrollBox) Draw(buff draw.Image) {
 }
 
 func (s *ScrollBox) update() {
-	updatedFlag := false
 	if s.paused {
 		return
 	}
+	updatedFlag := false
 	if s.dirX != 0 && time.Now().After(s.nextScrollX) {
 		pixelsMovedX := int64(time.Since(s.nextScrollX))/int64(s.scrollRateX) + 1
 		s.nextScrollX = time.Now().Add(s.scrollRateX)
@@ -92,12 +92,13 @@ func (s *ScrollBox) update() {
 	}
 }
 
-// Pause stops this scroll box from scrolling
+// Pause stops this scroll box from scrolling. Does nothing if already paused.
 func (s *ScrollBox) Pause() {
 	s.paused = true
 }
 
-// Unpause resumes this scroll box's scrolling
+// Unpause resumes this scroll box's scrolling. Will delay the next scroll frame
+// if already unpaused.
 func (s *ScrollBox) Unpause() {
 	s.paused = false
 	s.nextScrollX = time.Now().Add(s.scrollRateX)

--- a/render/scrollbox.go
+++ b/render/scrollbox.go
@@ -13,13 +13,12 @@ import (
 // for animating ticker tape feeds or rotating background animations.
 type ScrollBox struct {
 	*Sprite
+	pauseBool
 	Rs                       []Renderable
 	nextScrollX, nextScrollY time.Time
 	scrollRateX, scrollRateY time.Duration
 	View, reappear           physics.Vector
 	dirX, dirY               float64
-
-	paused bool
 }
 
 // NewScrollBox returns a ScrollBox of the input renderables and the given dimensions.
@@ -28,6 +27,7 @@ type ScrollBox struct {
 // will move in a negative direction.
 func NewScrollBox(rs []Renderable, milliPerPixelX, milliPerPixelY, width, height int) *ScrollBox {
 	s := new(ScrollBox)
+	s.pauseBool = pauseBool{playing: true}
 	s.Rs = rs
 	s.View = physics.NewVector(float64(width), float64(height))
 
@@ -55,7 +55,7 @@ func (s *ScrollBox) Draw(buff draw.Image) {
 }
 
 func (s *ScrollBox) update() {
-	if s.paused {
+	if !s.playing {
 		return
 	}
 	// ScrollBoxes update in a discontinuous fashion with Animation and Sequence
@@ -99,15 +99,10 @@ func (s *ScrollBox) update() {
 	}
 }
 
-// Pause stops this scroll box from scrolling. Does nothing if already paused.
-func (s *ScrollBox) Pause() {
-	s.paused = true
-}
-
 // Unpause resumes this scroll box's scrolling. Will delay the next scroll frame
 // if already unpaused.
 func (s *ScrollBox) Unpause() {
-	s.paused = false
+	s.pauseBool.Unpause()
 	s.nextScrollX = time.Now().Add(s.scrollRateX)
 	s.nextScrollY = time.Now().Add(s.scrollRateY)
 }

--- a/render/scrollbox_test.go
+++ b/render/scrollbox_test.go
@@ -1,0 +1,77 @@
+package render
+
+import (
+	"image/color"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScrollBoxFuncs(t *testing.T) {
+	// Scrollbox is another type that takes in w/h args that should
+	// return a potential error
+	// Alternatively: negative w/h should result in the w/h being multiplied
+	// by -1, and the whole renderable should shift -w, -h, but that would be
+	// meaningless for types that start at 0,0, because the common use case
+	// would be to set their position to some value afterword anyway.
+	sb := NewScrollBox(
+		// This could follow the same recommended syntax as sequence
+		[]Renderable{
+			NewColorBox(10, 10, color.RGBA{255, 255, 255, 255}),
+		},
+		50,
+		50,
+		20,
+		20,
+	)
+	rgba := sb.GetRGBA()
+	assert.Equal(t, rgba.At(0, 0), color.RGBA{255, 255, 255, 255})
+
+	// First shift check
+	time.Sleep(50 * time.Millisecond)
+	sb.update()
+	rgba = sb.GetRGBA()
+	assert.Equal(t, rgba.At(0, 0), color.RGBA{0, 0, 0, 0})
+
+	// Reappear / cycling check
+	time.Sleep(50 * 19 * time.Millisecond)
+	sb.update()
+	rgba = sb.GetRGBA()
+	assert.Equal(t, rgba.At(0, 0), color.RGBA{255, 255, 255, 255})
+
+	// AddRenderable
+	sb.AddRenderable(NewColorBox(5, 5, color.RGBA{0, 0, 255, 255}))
+	rgba = sb.GetRGBA()
+	assert.Equal(t, rgba.At(0, 0), color.RGBA{0, 0, 255, 255})
+
+	// High scroll rate / Pausing
+	sb.SetScrollRate(10000, 10000)
+	sb.Pause()
+	sb.update()
+	rgba = sb.GetRGBA()
+	assert.Equal(t, rgba.At(0, 0), color.RGBA{0, 0, 255, 255})
+	sb.Unpause()
+	time.Sleep(100 * time.Millisecond)
+	sb.update()
+	rgba = sb.GetRGBA()
+	assert.Equal(t, rgba.At(0, 0), color.RGBA{0, 0, 255, 255})
+
+	// Positive scrollRate/ reappearPos
+	assert.Nil(t, sb.SetReappearPos(-10, -10))
+	assert.NotNil(t, sb.SetReappearPos(10, -10))
+	assert.NotNil(t, sb.SetReappearPos(-10, 10))
+
+	// Zero scroll rate
+	sb.SetScrollRate(0, 0)
+	time.Sleep(100 * time.Millisecond)
+	sb.update()
+	rgba = sb.GetRGBA()
+	assert.Equal(t, rgba.At(0, 0), color.RGBA{0, 0, 255, 255})
+
+	// Negative scrollRate / reappearPos
+	sb.SetScrollRate(-100, -100)
+	assert.Nil(t, sb.SetReappearPos(10, 10))
+	assert.NotNil(t, sb.SetReappearPos(10, -10))
+	assert.NotNil(t, sb.SetReappearPos(-10, 10))
+}

--- a/render/sequence.go
+++ b/render/sequence.go
@@ -14,12 +14,12 @@ import (
 // primitive than animation, but less efficient.
 type Sequence struct {
 	LayeredPoint
+	pauseBool
 	rs            []Modifiable
 	lastChange    time.Time
 	sheetPos      int
 	frameTime     int64
 	cID           event.CID
-	playing       bool
 	Interruptable bool
 }
 
@@ -30,11 +30,13 @@ func NewSequence(mods []Modifiable, fps float64) *Sequence {
 		LayeredPoint: LayeredPoint{
 			Vector: physics.NewVector(0, 0),
 		},
+		pauseBool: pauseBool{
+			playing: true,
+		},
 		sheetPos:      0,
 		frameTime:     timing.FPSToNano(fps),
 		rs:            mods,
 		lastChange:    time.Now(),
-		playing:       true,
 		Interruptable: true,
 	}
 }
@@ -101,16 +103,6 @@ func (sq *Sequence) Modify(ms ...Modification) Modifiable {
 		r.Modify(ms...)
 	}
 	return sq
-}
-
-// Pause stops this sequence's animation
-func (sq *Sequence) Pause() {
-	sq.playing = false
-}
-
-// Unpause resumes this sequence's animation
-func (sq *Sequence) Unpause() {
-	sq.playing = true
 }
 
 // IsStatic returns false for sequences

--- a/render/sequence.go
+++ b/render/sequence.go
@@ -113,6 +113,11 @@ func (sq *Sequence) Unpause() {
 	sq.playing = true
 }
 
+// IsStatic returns false for sequences
+func (sq *Sequence) IsStatic() bool {
+	return false
+}
+
 // TweenSequence returns a sequence that is the tweening between the input images
 // at the given frame rate over the given frame count.
 func TweenSequence(a, b image.Image, frames int, fps float64) *Sequence {

--- a/render/sequence_test.go
+++ b/render/sequence_test.go
@@ -77,9 +77,13 @@ func TestSequenceFunctions(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	sq.update()
 	assert.Equal(t, sq.GetRGBA(), rgba1)
+
+	// Sequences have 6,6 dimensions right now. See LayeredPoint.
 	w, h := sq.GetDims()
 	assert.Equal(t, w, 6)
 	assert.Equal(t, h, 6)
+
+	assert.Equal(t, sq.IsStatic(), false)
 }
 
 func TestSequenceModify(t *testing.T) {

--- a/render/sequence_test.go
+++ b/render/sequence_test.go
@@ -1,0 +1,50 @@
+package render
+
+import (
+	"image/color"
+	"testing"
+	"time"
+
+	"github.com/oakmound/oak/event"
+)
+
+type Dummy struct{}
+
+func (d Dummy) Init() event.CID {
+	return event.NextID(d)
+}
+
+func TestSequenceTrigger(t *testing.T) {
+	sq := NewSequence(
+		// This syntax is bad for external calls,
+		// we could swap fps and make this variadic
+		[]Modifiable{
+			NewColorBox(10, 10, color.RGBA{255, 0, 0, 255}),
+			NewColorBox(10, 10, color.RGBA{0, 255, 0, 255}),
+		}, 5)
+	go event.ResolvePending()
+	cid := Dummy{}.Init()
+	sq.SetTriggerID(cid)
+	triggerCh := make(chan bool)
+	cid.Bind(func(int, interface{}) int {
+		// This is a bad idea in real code, this will lock up
+		// unbindings because the function that triggered this owns
+		// the lock on the event bus until this function exits.
+		// It is for this reason that all triggers, bindings,
+		// and unbindings do nothing when they are called, just put
+		// off work to be done-- to make sure no one is expecting a
+		// result from one of those functions, from within a triggered
+		// function, causing a deadlock.
+		//
+		// For this test this is the easiest way to do this though
+		triggerCh <- true
+		return 0
+	}, "AnimationEnd")
+	// We sleep to trigger the sequence to want to animate to the next frame
+	time.Sleep(1 * time.Second)
+	// Normally update is only called inside of Draw, so this is a pretend draw
+	sq.update()
+	time.Sleep(1 * time.Second)
+	sq.update()
+	<-triggerCh
+}

--- a/render/sprite.go
+++ b/render/sprite.go
@@ -36,11 +36,10 @@ func (s *Sprite) GetRGBA() *image.RGBA {
 // in the library we are using for polygon intersection. Too small objects
 // will always be considered to intersect a draw polygon.
 func (s *Sprite) GetDims() (int, int) {
-	rgba := s.r
-	if rgba == nil {
+	if s.r == nil {
 		return 6, 6
 	}
-	return rgba.Bounds().Max.X, rgba.Bounds().Max.Y
+	return s.r.Bounds().Max.X, s.r.Bounds().Max.Y
 }
 
 // SetRGBA will replace the rgba behind this sprite

--- a/render/sprite_test.go
+++ b/render/sprite_test.go
@@ -1,7 +1,7 @@
 package render
 
 import (
-	"fmt"
+	"image"
 	"image/color"
 	"testing"
 
@@ -11,9 +11,17 @@ import (
 )
 
 var (
+	// this is excessive for a lot of tests
+	// but it takes away some decision making
+	// and could reveal problems that probably aren't there
+	// but hey you never know
 	widths  = intrange.NewLinear(1, 10)
 	heights = intrange.NewLinear(1, 10)
 	colors  = colorrange.NewLinear(color.RGBA{0, 0, 0, 0}, color.RGBA{255, 255, 255, 255})
+)
+
+const (
+	fuzzCt = 10
 )
 
 // Todo for color boxes, and things that take w/h --
@@ -21,12 +29,11 @@ var (
 // right now that the inputs will be valid, which is a mistake
 // this is a breaking change for 2.0
 func TestColorBoxFuzz(t *testing.T) {
-	for i := 0; i < 100; i++ {
+	for i := 0; i < fuzzCt; i++ {
 		w := widths.Poll()
 		h := heights.Poll()
 		c := colors.Poll()
 		r, g, b, a := c.RGBA()
-		fmt.Println(r, g, b, a)
 		cb := NewColorBox(w, h, c)
 		rgba := cb.GetRGBA()
 		for x := 0; x < w; x++ {
@@ -41,3 +48,104 @@ func TestColorBoxFuzz(t *testing.T) {
 		}
 	}
 }
+
+// GradientBoxes should use color ranges internally
+
+func TestEmptySpriteFuzz(t *testing.T) {
+	for i := 0; i < fuzzCt; i++ {
+		w := widths.Poll()
+		h := heights.Poll()
+		s := NewEmptySprite(0, 0, w, h)
+		rgba := s.GetRGBA()
+		var zero uint32
+		for x := 0; x < w; x++ {
+			for y := 0; y < h; y++ {
+				c := rgba.At(x, y)
+				r, g, b, a := c.RGBA()
+				assert.Equal(t, r, zero)
+				assert.Equal(t, g, zero)
+				assert.Equal(t, b, zero)
+				assert.Equal(t, a, zero)
+			}
+		}
+	}
+}
+
+func TestSpriteFuncs(t *testing.T) {
+	s := NewEmptySprite(0, 0, 1, 1)
+	s2 := Sprite{}
+	s3 := s.Copy()
+
+	// Dims
+
+	w, h := s.GetDims()
+	assert.Equal(t, w, 1)
+	assert.Equal(t, h, 1)
+
+	w, h = s2.GetDims()
+	assert.Equal(t, w, 6)
+	assert.Equal(t, h, 6)
+
+	w, h = s3.GetDims()
+	assert.Equal(t, w, 1)
+	assert.Equal(t, h, 1)
+
+	// IsNil
+
+	assert.Equal(t, false, s.IsNil())
+	assert.Equal(t, true, s2.IsNil())
+	assert.Equal(t, false, s3.(*Sprite).IsNil())
+
+	// Set/GetRGBA
+
+	rgba := image.NewRGBA(image.Rect(0, 0, 4, 4))
+	s.SetRGBA(rgba)
+	rgba2 := s.GetRGBA()
+	assert.Equal(t, rgba, rgba2)
+}
+
+func TestOverlaySprites(t *testing.T) {
+	// This makes me wonder if overlay is easy enough to use
+	rgba := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	rgba.Set(0, 0, color.RGBA{255, 0, 0, 255})
+	// It should probably take in pointers
+	sprites := []Sprite{
+		*NewColorBox(2, 2, color.RGBA{0, 255, 0, 255}),
+		*NewSprite(0, 0, rgba),
+	}
+	overlay := OverlaySprites(sprites)
+	rgba = overlay.GetRGBA()
+	shouldRed := rgba.At(0, 0)
+	shouldGreen := rgba.At(0, 1)
+	assert.Equal(t, shouldRed, color.RGBA{255, 0, 0, 255})
+	assert.Equal(t, shouldGreen, color.RGBA{0, 255, 0, 255})
+}
+
+// Can't test ParseSubSprite without loading in something for it to return,
+// ParseSubSprite also ignores an error for no good reason?
+func TestParseSubSprite(t *testing.T) {
+	loadedImages["test"] = NewColorBox(100, 100, color.RGBA{255, 0, 0, 255}).GetRGBA()
+	sp := ParseSubSprite("test", 0, 0, 25, 25, 0)
+	rgba := sp.GetRGBA()
+	for x := 0; x < 25; x++ {
+		for y := 0; y < 25; y++ {
+			c := rgba.At(x, y)
+			r, g, b, a := c.RGBA()
+			assert.Equal(t, r, uint32(65535))
+			assert.Equal(t, g, uint32(0))
+			assert.Equal(t, b, uint32(0))
+			assert.Equal(t, a, uint32(65535))
+		}
+	}
+
+}
+
+func TestModifySprite(t *testing.T) {
+	s := NewColorBox(10, 10, color.RGBA{255, 0, 0, 255})
+	s2 := s.Modify(Cut(5, 5))
+	w, h := s2.GetDims()
+	assert.Equal(t, 5, w)
+	assert.Equal(t, 5, h)
+}
+
+// We'll cover drawing elsewhere

--- a/render/sprite_test.go
+++ b/render/sprite_test.go
@@ -18,6 +18,7 @@ var (
 	widths  = intrange.NewLinear(1, 10)
 	heights = intrange.NewLinear(1, 10)
 	colors  = colorrange.NewLinear(color.RGBA{0, 0, 0, 0}, color.RGBA{255, 255, 255, 255})
+	seeds   = intrange.NewLinear(0, 10000)
 )
 
 const (
@@ -50,6 +51,27 @@ func TestColorBoxFuzz(t *testing.T) {
 }
 
 // GradientBoxes should use color ranges internally
+
+func TestNoiseBoxFuzz(t *testing.T) {
+	for i := 0; i < fuzzCt; i++ {
+		w := widths.Poll()
+		h := heights.Poll()
+		seed := int64(seeds.Poll())
+		nb := NewSeededNoiseBox(w, h, seed)
+		nb2 := NewSeededNoiseBox(w, h, seed+1)
+		// This is a little awkward test, we could predict what a given seed
+		// will give us but this just confirms that adjacent seeds won't give
+		// us the same rgba.
+		assert.NotEqual(t, nb.GetRGBA(), nb2.GetRGBA())
+	}
+}
+
+func TestNoiseBox(t *testing.T) {
+	// I'm not sure what exactly we would test about these.
+	NewNoiseBox(10, 10)
+	NewNoiseSequence(10, 10, 10, 10)
+
+}
 
 func TestEmptySpriteFuzz(t *testing.T) {
 	for i := 0; i < fuzzCt; i++ {

--- a/render/sprite_test.go
+++ b/render/sprite_test.go
@@ -50,7 +50,76 @@ func TestColorBoxFuzz(t *testing.T) {
 	}
 }
 
-// GradientBoxes should use color ranges internally
+// GradientBoxes should use color ranges internally?
+func TestGradientBoxFuzz(t *testing.T) {
+	for i := 0; i < fuzzCt; i++ {
+		w := widths.Poll()
+		h := heights.Poll()
+		c1 := colors.Poll()
+		c2 := colors.Poll()
+		r, g, b, a := c1.RGBA()
+		r2, g2, b2, a2 := c2.RGBA()
+		cb := NewHorizontalGradientBox(w, h, c1, c2)
+		rgba := cb.GetRGBA()
+		for x := 0; x < w; x++ {
+			c3 := rgba.At(x, 0)
+			r3, g3, b3, a3 := c3.RGBA()
+			progress := float64(x) / float64(w)
+			// This sort of color math is frustrating
+			c4 := color.RGBA{
+				uint8(uint16OnScale(r, r2, progress) / 256),
+				uint8(uint16OnScale(g, g2, progress) / 256),
+				uint8(uint16OnScale(b, b2, progress) / 256),
+				uint8(uint16OnScale(a, a2, progress) / 256),
+			}
+			r4, g4, b4, a4 := c4.RGBA()
+			assert.Equal(t, r3, r4)
+			assert.Equal(t, g3, g4)
+			assert.Equal(t, b3, b4)
+			assert.Equal(t, a3, a4)
+		}
+		cb = NewVerticalGradientBox(w, h, c1, c2)
+		rgba = cb.GetRGBA()
+		for y := 0; y < h; y++ {
+			c3 := rgba.At(0, y)
+			r3, g3, b3, a3 := c3.RGBA()
+			progress := float64(y) / float64(h)
+			// This sort of color math is frustrating
+			c4 := color.RGBA{
+				uint8(uint16OnScale(r, r2, progress) / 256),
+				uint8(uint16OnScale(g, g2, progress) / 256),
+				uint8(uint16OnScale(b, b2, progress) / 256),
+				uint8(uint16OnScale(a, a2, progress) / 256),
+			}
+			r4, g4, b4, a4 := c4.RGBA()
+			assert.Equal(t, r3, r4)
+			assert.Equal(t, g3, g4)
+			assert.Equal(t, b3, b4)
+			assert.Equal(t, a3, a4)
+		}
+		cb = NewCircularGradientBox(w, h, c1, c2)
+		rgba = cb.GetRGBA()
+		for x := 0; x < w; x++ {
+			for y := 0; y < h; y++ {
+				c3 := rgba.At(x, y)
+				r3, g3, b3, a3 := c3.RGBA()
+				progress := CircularProgress(x, y, w, h)
+				// This sort of color math is frustrating
+				c4 := color.RGBA{
+					uint8(uint16OnScale(r, r2, progress) / 256),
+					uint8(uint16OnScale(g, g2, progress) / 256),
+					uint8(uint16OnScale(b, b2, progress) / 256),
+					uint8(uint16OnScale(a, a2, progress) / 256),
+				}
+				r4, g4, b4, a4 := c4.RGBA()
+				assert.Equal(t, r3, r4)
+				assert.Equal(t, g3, g4)
+				assert.Equal(t, b3, b4)
+				assert.Equal(t, a3, a4)
+			}
+		}
+	}
+}
 
 func TestNoiseBoxFuzz(t *testing.T) {
 	for i := 0; i < fuzzCt; i++ {

--- a/render/tween.go
+++ b/render/tween.go
@@ -22,25 +22,15 @@ func Tween(a image.Image, b image.Image, frames int) []*image.RGBA {
 				r1, g1, b1, a1 := a.At(x, y).RGBA()
 				r2, g2, b2, a2 := b.At(x, y).RGBA()
 
-				r1f := float64(r1)
-				g1f := float64(g1)
-				b1f := float64(b1)
-				a1f := float64(a1)
+				r1f := float64(r1) * (1 - progress)
+				g1f := float64(g1) * (1 - progress)
+				b1f := float64(b1) * (1 - progress)
+				a1f := float64(a1) * (1 - progress)
 
-				r2f := float64(r2)
-				g2f := float64(g2)
-				b2f := float64(b2)
-				a2f := float64(a2)
-
-				r1f *= 1 - progress
-				g1f *= 1 - progress
-				b1f *= 1 - progress
-				a1f *= 1 - progress
-
-				r2f *= progress
-				g2f *= progress
-				b2f *= progress
-				a2f *= progress
+				r2f := float64(r2) * progress
+				g2f := float64(g2) * progress
+				b2f := float64(b2) * progress
+				a2f := float64(a2) * progress
 
 				c := color.RGBA64{uint16(r1f + r2f), uint16(g1f + g2f),
 					uint16(b1f + b2f), uint16(a1f + a2f)}

--- a/render/tween.go
+++ b/render/tween.go
@@ -7,8 +7,8 @@ import (
 
 // Tween takes two images and returns a set of images tweening
 // between the two over some number of frames
-func Tween(a image.Image, b image.Image, frames int) []*image.RGBA {
-	bounds := a.Bounds()
+func Tween(start image.Image, end image.Image, frames int) []*image.RGBA {
+	bounds := start.Bounds()
 	w := bounds.Max.X
 	h := bounds.Max.Y
 
@@ -19,8 +19,8 @@ func Tween(a image.Image, b image.Image, frames int) []*image.RGBA {
 		tweened[i] = image.NewRGBA(image.Rect(0, 0, w, h))
 		for x := 0; x < w; x++ {
 			for y := 0; y < h; y++ {
-				r1, g1, b1, a1 := a.At(x, y).RGBA()
-				r2, g2, b2, a2 := b.At(x, y).RGBA()
+				r1, g1, b1, a1 := start.At(x, y).RGBA()
+				r2, g2, b2, a2 := end.At(x, y).RGBA()
 
 				r1f := float64(r1) * (1 - progress)
 				g1f := float64(g1) * (1 - progress)

--- a/render/tween_test.go
+++ b/render/tween_test.go
@@ -1,0 +1,27 @@
+package render
+
+import (
+	"image/color"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTween(t *testing.T) {
+	start := NewColorBox(10, 10, color.RGBA{0, 0, 0, 0})
+	end := NewColorBox(10, 10, color.RGBA{255, 255, 255, 255})
+	// I didn't expect to have to give frames - 2 here
+	tween := Tween(start.GetRGBA(), end.GetRGBA(), 254)
+	for i, rgba := range tween {
+		c := rgba.At(0, 0)
+		r, g, b, a := c.RGBA()
+		// I mean, I can guess that this should be near 255 but
+		// I had to just jump around to actually find 257 (and I've
+		// had to do this before, and remember this same experience)
+		v := uint32(257 * i)
+		assert.Equal(t, r, v)
+		assert.Equal(t, g, v)
+		assert.Equal(t, b, v)
+		assert.Equal(t, a, v)
+	}
+}


### PR DESCRIPTION
This adds locks around `render.Compound` types' operations so when calling `Add` on a `Compound` it won't potentially cause a map r/w crash. 

Because  I can't be bothered to cherry-pick that last commit, there are also some incremental improvements:

- Line drawing has been made more even.

- The `oak.oakConfig` struct has been renamed `oak.Config`. 

- A number of tests and docs have also been added.