### PR TITLE
Updated attachSpace tests to work after 2.2.0 fixes to tree

### DIFF
--- a/collision/attachSpace.go
+++ b/collision/attachSpace.go
@@ -82,8 +82,9 @@ func attachSpaceEnter(id int, nothing interface{}) int {
 	x, y := as.follow.X()+as.offX, as.follow.Y()+as.offY
 	if x != (*as.aSpace).X() ||
 		y != (*as.aSpace).Y() {
-		// An error here would only be the result of a nil pointer,
-		// which would crash already.
+
+		// If this was a nil pointer it would have already crashed but as of release 2.2.0 this could error from the space to delete not existing in the rtree.
+		// TODO: consider the case where as.aspace is not in the default rtree
 		UpdateSpace(x, y, (*as.aSpace).GetW(), (*as.aSpace).GetH(), *as.aSpace)
 	}
 	return 0

--- a/collision/attachSpace_test.go
+++ b/collision/attachSpace_test.go
@@ -29,6 +29,7 @@ func TestAttachSpace(t *testing.T) {
 	as := aspace{}
 	v := physics.NewVector(0, 0)
 	s := NewSpace(100, 100, 10, 10, as.Init())
+	Add(s)
 	assert.Nil(t, Attach(v, s, 4, 4))
 	v.SetPos(5, 5)
 	time.Sleep(200 * time.Millisecond)


### PR DESCRIPTION
Updated the test to add space to the default rtree