### PR TITLE
Clarify wording

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,5 +2,5 @@
 Please raise issues for discussion before making significant pull requests to
 packages not under `oak/entities/x`.
 
-Direct pull requests that are more than documentation / superficial changes at 
-`develop` to later be merged into `master` with a release number.
+Pull requests that are more than documentation / superficial changes should be
+directed to `develop` to later be merged into `master` with a release number.


### PR DESCRIPTION
The previous wording was unclear because "direct" could be interpreted as an adjective, in which case the sentence wouldn't make sense, as it would lack a verb.