### PR TITLE
fix StripOuterAlpha to actually be functional

### DIFF
--- a/render/mod/filter.go
+++ b/render/mod/filter.go
@@ -170,7 +170,7 @@ func InPlace(m Mod) Filter {
 }
 
 // StripOuterAlpha from the image given a source image and a alpha level to denote stripping.
-// Note that this was implement for ease of implementation but not speed.
+// Note that this was implemented for ease of implementation but not speed.
 // We could use image lib or a real depth first search to do fewer checks but this is easier...
 func StripOuterAlpha(m *image.RGBA, level int) Filter {
 	l := uint8(level)
@@ -193,7 +193,8 @@ func StripOuterAlpha(m *image.RGBA, level int) Filter {
 				r := mr.RGBAAt(x, y)
 				if r.A <= l {
 					// Treating as transparent
-					rgba.Set(int(x), int(y), mr.At(x, y))
+					r.A = 0
+					rgba.Set(int(x), int(y), r)
 				} else {
 					break
 				}
@@ -205,7 +206,8 @@ func StripOuterAlpha(m *image.RGBA, level int) Filter {
 				r := mr.RGBAAt(x, y)
 				if r.A <= l {
 					// Treating as transparent
-					rgba.Set(int(x), int(y), mr.At(x, y))
+					r.A = 0
+					rgba.Set(int(x), int(y), r)
 				} else {
 					break
 				}
@@ -218,7 +220,8 @@ func StripOuterAlpha(m *image.RGBA, level int) Filter {
 				r := mr.RGBAAt(x, y)
 				if r.A <= l {
 					// Treating as transparent
-					rgba.Set(int(x), int(y), mr.At(x, y))
+					r.A = 0
+					rgba.Set(int(x), int(y), r)
 				} else {
 					break
 				}
@@ -230,15 +233,13 @@ func StripOuterAlpha(m *image.RGBA, level int) Filter {
 				r := mr.RGBAAt(x, y)
 				if r.A <= l {
 					// Treating as transparent
-					rgba.Set(int(x), int(y), mr.At(x, y))
+					r.A = 0
+					rgba.Set(int(x), int(y), r)
 				} else {
 					break
 				}
 			}
 		}
-
-		// apply image onto m
-
 	}
 
 }

--- a/render/mod/mod_test.go
+++ b/render/mod/mod_test.go
@@ -96,7 +96,18 @@ func TestAllModifications(t *testing.T) {
 	}, {
 		InPlace(Scale(2, 2)),
 		setAll(newrgba(3, 3), color.RGBA{255, 0, 0, 255}),
-	}}
+	}, {
+		StripOuterAlpha(setOne(setOne(setOne(setOne(setAll(newrgba(3, 3), color.RGBA{255, 0, 0, 255}),
+			color.RGBA{0, 1, 0, 122}, 0, 0),
+			color.RGBA{0, 1, 0, 122}, 1, 0),
+			color.RGBA{0, 1, 0, 122}, 0, 1),
+			color.RGBA{0, 1, 0, 240}, 2, 2), 200),
+		setOne(setOne(setOne(setAll(newrgba(3, 3), color.RGBA{255, 0, 0, 255}),
+			color.RGBA{0, 1, 0, 0}, 0, 0),
+			color.RGBA{0, 1, 0, 0}, 1, 0),
+			color.RGBA{0, 1, 0, 0}, 0, 1),
+	},
+	}
 	for _, f := range filterList {
 		in2 := copyrgba(in)
 		f.Filter(in2)


### PR DESCRIPTION
Creating this as a pull request as I am not sure it should be executed on.

Namely there existed an untested function that did not do what it stated and instead when used this filter would only ever fail and return an error or fail to update the image.

There is of course the possible argument that we should just remove the function entirely or not touch it as there could be existing consumers... but in my mind this is the right path.