### PR TITLE
event: add SetCallerMap to Bus and Handler

### DIFF
--- a/event/bus.go
+++ b/event/bus.go
@@ -60,6 +60,11 @@ func NewBus(callerMap *CallerMap) *Bus {
 	}
 }
 
+// SetCallerMap updates a bus to use a specific set of callers.
+func (b *Bus) SetCallerMap(cm *CallerMap) {
+	b.callerMap = cm
+}
+
 // An Event is an event name and an associated caller id
 type Event struct {
 	Name     string

--- a/event/handler.go
+++ b/event/handler.go
@@ -14,8 +14,6 @@ var (
 // Handler represents the necessary exported functions from an event.Bus
 // for use in oak internally, and thus the functions that need to be replaced
 // by alternative event handlers.
-// TODO V3: consider breaking down the bus into smaller components
-// for easier composition for external handler implementations
 type Handler interface {
 	WaitForEvent(name string) <-chan interface{}
 	// <Handler>
@@ -40,6 +38,8 @@ type Handler interface {
 	UnbindAll(Event)
 	UnbindAllAndRebind(Event, []Bindable, CID, []string)
 	UnbindBindable(UnbindOption)
+
+	SetCallerMap(*CallerMap)
 }
 
 // UpdateLoop is expected to internally call Update()

--- a/sceneLoop.go
+++ b/sceneLoop.go
@@ -130,6 +130,7 @@ func (w *Window) sceneLoop(first string, trackingInputs bool) {
 		} else {
 			w.CallerMap = event.NewCallerMap()
 		}
+		w.eventHandler.SetCallerMap(w.CallerMap)
 		w.DrawStack.Clear()
 		w.DrawStack.PreDraw()
 


### PR DESCRIPTION
Hotfix immediately following release, as is mandatory. 

Need to evaluate the problem more closely to ensure this fixes it-- but the caller map for non-default event buses did not line up with the caller map that was owned by the window itself.  @Implausiblyfun 