### PR TITLE
Browser support via go WASM

### DIFF
--- a/audio/klang/encode_fallback.go
+++ b/audio/klang/encode_fallback.go
@@ -1,4 +1,5 @@
-//+build darwin
+//+build !linux
+//+build !windows
 
 package klang
 

--- a/collision/label.go
+++ b/collision/label.go
@@ -3,7 +3,6 @@ package collision
 const (
 	// NilLabel is used internally for spaces that are otherwise not
 	// given labels.
-	// TODO V3: why is this exported
 	NilLabel Label = -1
 )
 

--- a/config.go
+++ b/config.go
@@ -164,8 +164,6 @@ func ReaderConfig(r io.Reader) ConfigOption {
 }
 
 func (c Config) overwriteFrom(c2 Config) Config {
-	// TODO: is this the right place for these configuration pieces?
-	// TODO: is there other configuration that should go here?
 	if c2.Assets.AudioPath != "" {
 		c.Assets.AudioPath = c2.Assets.AudioPath
 	}

--- a/dlog/default.go
+++ b/dlog/default.go
@@ -43,8 +43,6 @@ func NewLogger() Logger {
 // containing the logged data separated by spaces,
 // prepended with file and line information.
 // It only includes logs which pass the current filters.
-// Todo: use io.Multiwriter to simplify the writing to
-// both logfiles and stdout
 func (l *logger) dLog(level Level, in ...interface{}) {
 	//(pc uintptr, file string, line int, ok bool)
 	_, f, line, ok := runtime.Caller(2)

--- a/event/bus.go
+++ b/event/bus.go
@@ -60,6 +60,11 @@ func NewBus(callerMap *CallerMap) *Bus {
 	}
 }
 
+// SetCallerMap updates a bus to use a specific set of callers.
+func (b *Bus) SetCallerMap(cm *CallerMap) {
+	b.callerMap = cm
+}
+
 // An Event is an event name and an associated caller id
 type Event struct {
 	Name     string

--- a/event/handler.go
+++ b/event/handler.go
@@ -14,8 +14,6 @@ var (
 // Handler represents the necessary exported functions from an event.Bus
 // for use in oak internally, and thus the functions that need to be replaced
 // by alternative event handlers.
-// TODO V3: consider breaking down the bus into smaller components
-// for easier composition for external handler implementations
 type Handler interface {
 	WaitForEvent(name string) <-chan interface{}
 	// <Handler>
@@ -40,6 +38,8 @@ type Handler interface {
 	UnbindAll(Event)
 	UnbindAllAndRebind(Event, []Bindable, CID, []string)
 	UnbindBindable(UnbindOption)
+
+	SetCallerMap(*CallerMap)
 }
 
 // UpdateLoop is expected to internally call Update()

--- a/mouse/mouse.go
+++ b/mouse/mouse.go
@@ -20,8 +20,6 @@ const (
 	ButtonNone       = mouse.ButtonNone
 )
 
-//TODO V3: should event names be strings?
-
 // GetEventName returns a string event name given some mobile/mouse information
 func GetEventName(d mouse.Direction, b mouse.Button) string {
 	switch d {

--- a/sceneLoop.go
+++ b/sceneLoop.go
@@ -130,6 +130,7 @@ func (w *Window) sceneLoop(first string, trackingInputs bool) {
 		} else {
 			w.CallerMap = event.NewCallerMap()
 		}
+		w.eventHandler.SetCallerMap(w.CallerMap)
 		w.DrawStack.Clear()
 		w.DrawStack.PreDraw()
 

--- a/shiny/driver/driver_fallback.go
+++ b/shiny/driver/driver_fallback.go
@@ -8,6 +8,7 @@
 // +build !dragonfly
 // +build !openbsd
 // +build !nooswindow
+// +build !js
 
 package driver
 

--- a/shiny/driver/driver_js.go
+++ b/shiny/driver/driver_js.go
@@ -1,0 +1,17 @@
+//go:build js && !nooswindow && !windows && !darwin && !linux
+// +build js,!nooswindow,!windows,!darwin,!linux
+
+package driver
+
+import (
+	"github.com/oakmound/oak/v3/shiny/driver/jsdriver"
+	"github.com/oakmound/oak/v3/shiny/screen"
+)
+
+func main(f func(screen.Screen)) {
+	jsdriver.Main(f)
+}
+
+func monitorSize() (int, int) {
+	return 0, 0
+}

--- a/shiny/driver/jsdriver/canvas.go
+++ b/shiny/driver/jsdriver/canvas.go
@@ -1,0 +1,45 @@
+package jsdriver
+
+import (
+	"image"
+	"syscall/js"
+)
+
+// Adapted from Mark Farnan's go-canvas library (github.com/markfarnan/go-canvas)
+type Canvas2D struct {
+	// DOM properties
+	window js.Value
+	doc    js.Value
+	body   js.Value
+
+	// Canvas properties
+	canvas  js.Value
+	ctx     js.Value
+	imgData js.Value
+
+	copybuff js.Value
+}
+
+func NewCanvas2d(width int, height int) *Canvas2D {
+	var c Canvas2D
+	c.window = js.Global()
+	c.doc = c.window.Get("document")
+	c.body = c.doc.Get("body")
+
+	canvas := c.doc.Call("createElement", "canvas")
+
+	canvas.Set("height", height)
+	canvas.Set("width", width)
+	// TODO: screen position
+	c.body.Call("appendChild", canvas)
+
+	c.canvas = canvas
+
+	// Setup the 2D Drawing context
+	c.ctx = c.canvas.Call("getContext", "2d")
+	c.imgData = c.ctx.Call("createImageData", width, height) // Note Width, then Height
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	c.copybuff = js.Global().Get("Uint8Array").New(len(img.Pix)) // Static JS buffer for copying data out to JS. Defined once and re-used to save on un-needed allocations
+
+	return &c
+}

--- a/shiny/driver/jsdriver/image.go
+++ b/shiny/driver/jsdriver/image.go
@@ -1,0 +1,23 @@
+package jsdriver
+
+import "image"
+
+type imageImpl struct {
+	screen *screenImpl
+	size   image.Point
+	rgba   *image.RGBA
+}
+
+func (ii imageImpl) Size() image.Point {
+	return ii.size
+}
+
+func (ii imageImpl) Bounds() image.Rectangle {
+	return image.Rect(0, 0, ii.size.X, ii.size.Y)
+}
+
+func (imageImpl) Release() {}
+
+func (ii imageImpl) RGBA() *image.RGBA {
+	return ii.rgba
+}

--- a/shiny/driver/jsdriver/texture.go
+++ b/shiny/driver/jsdriver/texture.go
@@ -1,0 +1,30 @@
+package jsdriver
+
+import (
+	"image"
+	"image/color"
+	"image/draw"
+
+	"github.com/oakmound/oak/v3/shiny/screen"
+)
+
+type textureImpl struct {
+	screen *screenImpl
+	size   image.Point
+	rgba   *image.RGBA
+}
+
+func (ti *textureImpl) Size() image.Point {
+	return ti.size
+}
+
+func (ti *textureImpl) Bounds() image.Rectangle {
+	return image.Rect(0, 0, ti.size.X, ti.size.Y)
+}
+
+func (ti *textureImpl) Upload(dp image.Point, src screen.Image, sr image.Rectangle) {
+	rgba := src.RGBA()
+	ti.rgba = rgba
+}
+func (*textureImpl) Fill(dr image.Rectangle, src color.Color, op draw.Op) {}
+func (*textureImpl) Release()                                             {}

--- a/shiny/driver/jsdriver/window.go
+++ b/shiny/driver/jsdriver/window.go
@@ -1,0 +1,133 @@
+package jsdriver
+
+import (
+	"fmt"
+	"image"
+	"image/color"
+	"image/draw"
+	"syscall/js"
+
+	"github.com/oakmound/oak/v3/shiny/driver/internal/event"
+	"github.com/oakmound/oak/v3/shiny/screen"
+	"golang.org/x/image/math/f64"
+	"golang.org/x/mobile/event/key"
+	"golang.org/x/mobile/event/mouse"
+)
+
+type windowImpl struct {
+	screen *screenImpl
+	cvs    *Canvas2D
+	event.Deque
+}
+
+func (w *windowImpl) Release()                                                                      {}
+func (w *windowImpl) Draw(src2dst f64.Aff3, src screen.Texture, sr image.Rectangle, op draw.Op)     {}
+func (w *windowImpl) DrawUniform(src2dst f64.Aff3, src color.Color, sr image.Rectangle, op draw.Op) {}
+func (w *windowImpl) Copy(dp image.Point, src screen.Texture, sr image.Rectangle, op draw.Op)       {}
+func (w *windowImpl) Scale(dr image.Rectangle, src screen.Texture, sr image.Rectangle, op draw.Op) {
+	rgba := src.(*textureImpl).rgba
+	js.CopyBytesToJS(w.cvs.copybuff, rgba.Pix)
+	w.cvs.imgData.Get("data").Call("set", w.cvs.copybuff)
+	w.cvs.ctx.Call("putImageData", w.cvs.imgData, 0, 0)
+}
+func (w *windowImpl) Upload(dp image.Point, src screen.Image, sr image.Rectangle) {}
+func (w *windowImpl) Fill(dr image.Rectangle, src color.Color, op draw.Op)        {}
+
+func (w *windowImpl) Publish() screen.PublishResult {
+	return screen.PublishResult{}
+}
+
+func (w *windowImpl) sendMouseEvent(mouseEvent js.Value, dir mouse.Direction) {
+	x, y := mouseEvent.Get("offsetX"), mouseEvent.Get("offsetY")
+	w.Send(mouse.Event{
+		X:         float32(x.Float()),
+		Y:         float32(y.Float()),
+		Direction: dir,
+	})
+}
+
+func (w *windowImpl) sendKeyEvent(keyEvent js.Value, dir key.Direction) {
+	var mods key.Modifiers
+	if keyEvent.Get("shiftKey").Bool() {
+		mods |= key.ModShift
+	}
+	if keyEvent.Get("metaKey").Bool() {
+		mods |= key.ModMeta
+	}
+	if keyEvent.Get("ctrlKey").Bool() {
+		mods |= key.ModControl
+	}
+	if keyEvent.Get("altKey").Bool() {
+		mods |= key.ModAlt
+	}
+	if keyEvent.Get("repeat").Bool() {
+		dir = key.DirNone
+	}
+	w.Send(key.Event{
+		Modifiers: mods,
+		Code:      parseKeyCode(keyEvent.Get("code").String()),
+		Rune:      rune(keyEvent.Get("key").String()[0]),
+		Direction: dir,
+	})
+}
+
+func parseKeyCode(cd string) key.Code {
+	switch cd {
+	case "KeyA":
+		return key.CodeA
+	case "KeyB":
+		return key.CodeB
+	case "KeyC":
+		return key.CodeC
+	case "KeyD":
+		return key.CodeD
+	case "KeyE":
+		return key.CodeE
+	case "KeyF":
+		return key.CodeF
+	case "KeyG":
+		return key.CodeG
+	case "KeyH":
+		return key.CodeH
+	case "KeyI":
+		return key.CodeI
+	case "KeyJ":
+		return key.CodeJ
+	case "KeyK":
+		return key.CodeK
+	case "KeyL":
+		return key.CodeL
+	case "KeyM":
+		return key.CodeM
+	case "KeyN":
+		return key.CodeN
+	case "KeyO":
+		return key.CodeO
+	case "KeyP":
+		return key.CodeP
+	case "KeyQ":
+		return key.CodeQ
+	case "KeyR":
+		return key.CodeR
+	case "KeyS":
+		return key.CodeS
+	case "KeyT":
+		return key.CodeT
+	case "KeyU":
+		return key.CodeU
+	case "KeyV":
+		return key.CodeV
+	case "KeyW":
+		return key.CodeW
+	case "KeyX":
+		return key.CodeX
+	case "KeyY":
+		return key.CodeY
+	case "KeyZ":
+		return key.CodeZ
+	// TODO: more keys
+	default:
+		fmt.Println("unknown key", cd)
+		return key.CodeUnknown
+	}
+}

--- a/viewport_test.go
+++ b/viewport_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func sleep() {
-	// TODO V3: test how far we can bring this down and get consistent results
+	// TODO: test how far we can bring this down and get consistent results
 	time.Sleep(300 * time.Millisecond)
 }
 


### PR DESCRIPTION
Example status:
- [x] bezier -> hangs if you try drawing too complex a bezier
- [x] blank
- [x] click-propagation
- [ ] clipboard -> untested, needs custom fixing, library does not support js
- [x] collision-demo
- [x] custom-cursor
- [x] error-scene
- [ ] fallback-font -> untested
- [x] flappy-bird
- [ ] joystick-viz -> untested, needs custom joystick driver 
- [x] keyboard-test
- [ ] multi-window -> untested, almost certainly does not work
- [ ] particle-demo -> crashes, hanging
- [ ] platformer-tutorial -> untested
- [x] pong
- [ ] radar-demo -> untested
- [ ] rooms -> crashes, hanging
- [ ] screenopts -> untested, these options are probably not viable
- [ ] slide -> untested
- [ ] sprite-demo -> untested
- [ ] svg -> untested
- [x] text-demo-1
- [ ] text-demo-2 -> crashes, hanging
- [x] titlescreen-demo
- [ ] top-down-shooter-tutorial -> untested
- [ ] zooming -> crashes, hanging