### PR TITLE
oak: update contributing to note develop being dropped

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,4 @@
 # Contributing
+
 Please raise issues for discussion before making significant pull requests to
 packages not under `oak/entities/x`.
-
-Pull requests that are more than documentation / superficial changes should be
-directed to `develop` to later be merged into `master` with a release number.


### PR DESCRIPTION
using develop made sense pre go modules, when it was likely a user would pull an unpinned version unintentionally, but that chance is much lower now.