### PR TITLE
alg\floatgeom: Fix Polygon rect collision overeager singledimension overlap

### DIFF
--- a/alg/floatgeom/polygon.go
+++ b/alg/floatgeom/polygon.go
@@ -137,14 +137,18 @@ func (pg Polygon2) RectCollides(r Rect2) bool {
 	dx2 := pg.Bounding.Max.X()
 	dy2 := pg.Bounding.Max.Y()
 
+	overlapX := false
 	if x > dx {
 		if x < dx2 {
-			return pg.OverlappingRectCollides(r)
+			overlapX = true
 		}
 	} else {
 		if dx < x2 {
-			return pg.OverlappingRectCollides(r)
+			overlapX = true
 		}
+	}
+	if !overlapX {
+		return false
 	}
 	if y > dy {
 		if y < dy2 {

--- a/alg/floatgeom/polygon_test.go
+++ b/alg/floatgeom/polygon_test.go
@@ -119,6 +119,15 @@ func TestPolygon2_RectCollides(t *testing.T) {
 			rect:          NewRect2(0, 0, 2, 2),
 			shouldCollide: true,
 		},
+		{
+			poly: NewPolygon2(
+				Point2{1.1, 1.1},
+				Point2{1.1, 1.1},
+				Point2{1.1, 1.1},
+			),
+			rect:          NewRect2(0, 2, 2, 2),
+			shouldCollide: false,
+		},
 	}
 	for i, tc := range tcs {
 		if tc.poly.RectCollides(tc.rect) != tc.shouldCollide {


### PR DESCRIPTION
Polygon overlap checks have 2 parts. In the first part we attempt to see if the bounding rectangles overlap.

Previously if the bounding rectangles overlapped in a single dimension we claimed they overlapped which is incorrect.
This led to claims of overlap in instances where it should not have occured.