### PR TITLE
Default OSFallback to false for JS builds

### DIFF
--- a/fileutil/os_fallback_js.go
+++ b/fileutil/os_fallback_js.go
@@ -1,8 +1,7 @@
-
-package fileutil 
-
 //go:build js
 // +build js
+
+package fileutil 
 
 func init() {
 	// OS calls always fall in JS, disable calling to it by default 

--- a/fileutil/os_fallback_js.go
+++ b/fileutil/os_fallback_js.go
@@ -1,0 +1,10 @@
+
+package fileutil 
+
+//go:build js
+// +build js
+
+func init() {
+	// OS calls always fall in JS, disable calling to it by default 
+	OSFallback = false 
+}


### PR DESCRIPTION
For JS targets, a call to the standard library's `os` package to open a file will always error. This change alters the `fileutil` package, where all of oak's os file calls happen (outside of driver specific operations), to default to not make OS calls if the embedded file system fails a file lookup. 