### PR TITLE
scene: Embed Eventhandler to allow for some embedded calls

### DIFF
--- a/debugtools/inputviz/joystick.go
+++ b/debugtools/inputviz/joystick.go
@@ -183,13 +183,13 @@ func (j *Joystick) RenderAndListen(ctx *scene.Context, joy *joystick.Joystick, l
 		joystick.InputRightShoulder,
 	}
 
-	b1 := event.Bind(ctx.EventHandler, joystick.Disconnected, j, func(rend *Joystick, _ uint32) event.Response {
+	b1 := event.Bind(ctx.Handler, joystick.Disconnected, j, func(rend *Joystick, _ uint32) event.Response {
 		j.Destroy()
 		return 0
 	})
 
 	// TODO: it is bad that you need to import two 'key' packages
-	b2 := event.Bind(ctx.EventHandler, key.Down(mkey.CodeSpacebar), j, func(j *Joystick, _ key.Event) event.Response {
+	b2 := event.Bind(ctx.Handler, key.Down(mkey.CodeSpacebar), j, func(j *Joystick, _ key.Event) event.Response {
 		j.joy.Vibrate(math.MaxUint16, math.MaxUint16)
 		go func() {
 			time.Sleep(1 * time.Second)
@@ -198,7 +198,7 @@ func (j *Joystick) RenderAndListen(ctx *scene.Context, joy *joystick.Joystick, l
 		return 0
 	})
 
-	b3 := event.Bind(ctx.EventHandler, joystick.Change, j, func(j *Joystick, st *joystick.State) event.Response {
+	b3 := event.Bind(ctx.Handler, joystick.Change, j, func(j *Joystick, st *joystick.State) event.Response {
 		for _, inputB := range bts {
 			b := string(inputB)
 			r := j.rs[b]
@@ -220,7 +220,7 @@ func (j *Joystick) RenderAndListen(ctx *scene.Context, joy *joystick.Joystick, l
 		return 0
 	})
 
-	b4 := event.Bind(ctx.EventHandler, joystick.LtStickChange, j, func(j *Joystick, st *joystick.State) event.Response {
+	b4 := event.Bind(ctx.Handler, joystick.LtStickChange, j, func(j *Joystick, st *joystick.State) event.Response {
 		pos := j.lStickCenter
 		pos = pos.Add(floatgeom.Point2{
 			float64(st.StickLX / 2048),
@@ -230,7 +230,7 @@ func (j *Joystick) RenderAndListen(ctx *scene.Context, joy *joystick.Joystick, l
 		return 0
 	})
 
-	b5 := event.Bind(ctx.EventHandler, joystick.RtStickChange, j, func(j *Joystick, st *joystick.State) event.Response {
+	b5 := event.Bind(ctx.Handler, joystick.RtStickChange, j, func(j *Joystick, st *joystick.State) event.Response {
 		pos := j.rStickCenter
 		pos = pos.Add(floatgeom.Point2{
 			float64(st.StickRX / 2048),

--- a/debugtools/inputviz/joystick.go
+++ b/debugtools/inputviz/joystick.go
@@ -183,13 +183,13 @@ func (j *Joystick) RenderAndListen(ctx *scene.Context, joy *joystick.Joystick, l
 		joystick.InputRightShoulder,
 	}
 
-	b1 := event.Bind(ctx.Handler, joystick.Disconnected, j, func(rend *Joystick, _ uint32) event.Response {
+	b1 := event.Bind(ctx, joystick.Disconnected, j, func(rend *Joystick, _ uint32) event.Response {
 		j.Destroy()
 		return 0
 	})
 
 	// TODO: it is bad that you need to import two 'key' packages
-	b2 := event.Bind(ctx.Handler, key.Down(mkey.CodeSpacebar), j, func(j *Joystick, _ key.Event) event.Response {
+	b2 := event.Bind(ctx, key.Down(mkey.CodeSpacebar), j, func(j *Joystick, _ key.Event) event.Response {
 		j.joy.Vibrate(math.MaxUint16, math.MaxUint16)
 		go func() {
 			time.Sleep(1 * time.Second)
@@ -198,7 +198,7 @@ func (j *Joystick) RenderAndListen(ctx *scene.Context, joy *joystick.Joystick, l
 		return 0
 	})
 
-	b3 := event.Bind(ctx.Handler, joystick.Change, j, func(j *Joystick, st *joystick.State) event.Response {
+	b3 := event.Bind(ctx, joystick.Change, j, func(j *Joystick, st *joystick.State) event.Response {
 		for _, inputB := range bts {
 			b := string(inputB)
 			r := j.rs[b]
@@ -220,7 +220,7 @@ func (j *Joystick) RenderAndListen(ctx *scene.Context, joy *joystick.Joystick, l
 		return 0
 	})
 
-	b4 := event.Bind(ctx.Handler, joystick.LtStickChange, j, func(j *Joystick, st *joystick.State) event.Response {
+	b4 := event.Bind(ctx, joystick.LtStickChange, j, func(j *Joystick, st *joystick.State) event.Response {
 		pos := j.lStickCenter
 		pos = pos.Add(floatgeom.Point2{
 			float64(st.StickLX / 2048),
@@ -230,7 +230,7 @@ func (j *Joystick) RenderAndListen(ctx *scene.Context, joy *joystick.Joystick, l
 		return 0
 	})
 
-	b5 := event.Bind(ctx.Handler, joystick.RtStickChange, j, func(j *Joystick, st *joystick.State) event.Response {
+	b5 := event.Bind(ctx, joystick.RtStickChange, j, func(j *Joystick, st *joystick.State) event.Response {
 		pos := j.rStickCenter
 		pos = pos.Add(floatgeom.Point2{
 			float64(st.StickRX / 2048),

--- a/debugtools/inputviz/keyboard.go
+++ b/debugtools/inputviz/keyboard.go
@@ -221,7 +221,7 @@ func (k *Keyboard) RenderAndListen(ctx *scene.Context, layer int) error {
 		}
 	}
 
-	b1 := event.Bind(ctx.Handler, key.AnyDown, k, func(kb *Keyboard, ev key.Event) event.Response {
+	b1 := event.Bind(ctx, key.AnyDown, k, func(kb *Keyboard, ev key.Event) event.Response {
 		btn := ev.Code.String()[4:]
 		if kb.rs[btn] == nil {
 			return 0
@@ -229,7 +229,7 @@ func (k *Keyboard) RenderAndListen(ctx *scene.Context, layer int) error {
 		kb.rs[btn].Set("pressed")
 		return 0
 	})
-	b2 := event.Bind(ctx.Handler, key.AnyUp, k, func(kb *Keyboard, ev key.Event) event.Response {
+	b2 := event.Bind(ctx, key.AnyUp, k, func(kb *Keyboard, ev key.Event) event.Response {
 		btn := ev.Code.String()[4:]
 		if kb.rs[btn] == nil {
 			return 0

--- a/debugtools/inputviz/keyboard.go
+++ b/debugtools/inputviz/keyboard.go
@@ -221,7 +221,7 @@ func (k *Keyboard) RenderAndListen(ctx *scene.Context, layer int) error {
 		}
 	}
 
-	b1 := event.Bind(ctx.EventHandler, key.AnyDown, k, func(kb *Keyboard, ev key.Event) event.Response {
+	b1 := event.Bind(ctx.Handler, key.AnyDown, k, func(kb *Keyboard, ev key.Event) event.Response {
 		btn := ev.Code.String()[4:]
 		if kb.rs[btn] == nil {
 			return 0
@@ -229,7 +229,7 @@ func (k *Keyboard) RenderAndListen(ctx *scene.Context, layer int) error {
 		kb.rs[btn].Set("pressed")
 		return 0
 	})
-	b2 := event.Bind(ctx.EventHandler, key.AnyUp, k, func(kb *Keyboard, ev key.Event) event.Response {
+	b2 := event.Bind(ctx.Handler, key.AnyUp, k, func(kb *Keyboard, ev key.Event) event.Response {
 		btn := ev.Code.String()[4:]
 		if kb.rs[btn] == nil {
 			return 0

--- a/debugtools/inputviz/mouse.go
+++ b/debugtools/inputviz/mouse.go
@@ -37,7 +37,7 @@ func (m *Mouse) CID() event.CallerID {
 
 func (m *Mouse) RenderAndListen(ctx *scene.Context, layer int) error {
 	m.ctx = ctx
-	handler := ctx.EventHandler
+	handler := ctx.Handler
 	m.CallerID = handler.GetCallerMap().Register(m)
 
 	if m.Rect.W() == 0 || m.Rect.H() == 0 {

--- a/debugtools/inputviz/mouse.go
+++ b/debugtools/inputviz/mouse.go
@@ -37,8 +37,7 @@ func (m *Mouse) CID() event.CallerID {
 
 func (m *Mouse) RenderAndListen(ctx *scene.Context, layer int) error {
 	m.ctx = ctx
-	handler := ctx.Handler
-	m.CallerID = handler.GetCallerMap().Register(m)
+	m.CallerID = ctx.Handler.GetCallerMap().Register(m)
 
 	if m.Rect.W() == 0 || m.Rect.H() == 0 {
 		m.Rect.Max = m.Rect.Min.Add(floatgeom.Point2{60, 100})
@@ -100,21 +99,21 @@ func (m *Mouse) RenderAndListen(ctx *scene.Context, layer int) error {
 		ctx.DrawStack.Draw(m.posText, m.BaseLayer, layer+2)
 	}
 
-	b1 := event.Bind(handler, mouse.Press, m, func(m *Mouse, ev *mouse.Event) event.Response {
+	b1 := event.Bind(ctx, mouse.Press, m, func(m *Mouse, ev *mouse.Event) event.Response {
 		m.rs[ev.Button].Set("pressed")
 		m.stateIncLock.Lock()
 		m.stateInc[ev.Button]++
 		m.stateIncLock.Unlock()
 		return 0
 	})
-	b2 := event.Bind(handler, mouse.Release, m, func(m *Mouse, ev *mouse.Event) event.Response {
+	b2 := event.Bind(ctx, mouse.Release, m, func(m *Mouse, ev *mouse.Event) event.Response {
 		m.rs[ev.Button].Set("released")
 		m.stateIncLock.Lock()
 		m.stateInc[ev.Button]++
 		m.stateIncLock.Unlock()
 		return 0
 	})
-	b3 := event.Bind(handler, mouse.ScrollDown, m, func(m *Mouse, ev *mouse.Event) event.Response {
+	b3 := event.Bind(ctx, mouse.ScrollDown, m, func(m *Mouse, ev *mouse.Event) event.Response {
 		m.rs[mouse.ButtonMiddle].Set("scrolldown")
 		m.stateIncLock.Lock()
 		m.stateInc[mouse.ButtonMiddle]++
@@ -129,7 +128,7 @@ func (m *Mouse) RenderAndListen(ctx *scene.Context, layer int) error {
 		})
 		return 0
 	})
-	b4 := event.Bind(handler, mouse.ScrollUp, m, func(m *Mouse, ev *mouse.Event) event.Response {
+	b4 := event.Bind(ctx, mouse.ScrollUp, m, func(m *Mouse, ev *mouse.Event) event.Response {
 		m.rs[mouse.ButtonMiddle].Set("scrollup")
 		m.stateIncLock.Lock()
 		m.stateInc[mouse.ButtonMiddle]++
@@ -144,7 +143,7 @@ func (m *Mouse) RenderAndListen(ctx *scene.Context, layer int) error {
 		})
 		return 0
 	})
-	b5 := event.Bind(handler, mouse.Drag, m, func(m *Mouse, ev *mouse.Event) event.Response {
+	b5 := event.Bind(ctx, mouse.Drag, m, func(m *Mouse, ev *mouse.Event) event.Response {
 		m.lastMousePos.Point2 = ev.Point2
 		return 0
 	})

--- a/debugtools/mouse.go
+++ b/debugtools/mouse.go
@@ -10,7 +10,7 @@ import (
 // DebugMouseRelease will print the position and button pressed of the mouse when the mouse is released, if the given
 // key is held down at the time. If no key is given, it will always be printed
 func DebugMouseRelease(ctx *scene.Context, k string) {
-	event.GlobalBind(ctx.Handler, mouse.Release, func(mev *mouse.Event) event.Response {
+	event.GlobalBind(ctx, mouse.Release, func(mev *mouse.Event) event.Response {
 		if k == "" || ctx.KeyState.IsDown(k) {
 			dlog.Info(mev)
 		}

--- a/debugtools/mouse.go
+++ b/debugtools/mouse.go
@@ -10,7 +10,7 @@ import (
 // DebugMouseRelease will print the position and button pressed of the mouse when the mouse is released, if the given
 // key is held down at the time. If no key is given, it will always be printed
 func DebugMouseRelease(ctx *scene.Context, k string) {
-	event.GlobalBind(ctx.EventHandler, mouse.Release, func(mev *mouse.Event) event.Response {
+	event.GlobalBind(ctx.Handler, mouse.Release, func(mev *mouse.Event) event.Response {
 		if k == "" || ctx.KeyState.IsDown(k) {
 			dlog.Info(mev)
 		}

--- a/event/caller.go
+++ b/event/caller.go
@@ -72,8 +72,8 @@ func (cm *CallerMap) DestroyEntity(id CallerID) {
 	cm.callersLock.Unlock()
 }
 
-// Reset clears the caller map to forget all registered callers.
-func (cm *CallerMap) Reset() {
+// Clear clears the caller map to forget all registered callers.
+func (cm *CallerMap) Clear() {
 	cm.callersLock.Lock()
 	*cm.highestID = 0
 	cm.callers = map[CallerID]Caller{}

--- a/examples/bezier/main.go
+++ b/examples/bezier/main.go
@@ -55,7 +55,7 @@ func main() {
 
 	oak.AddScene("bezier", scene.Scene{Start: func(ctx *scene.Context) {
 		mouseFloats := []float64{}
-		event.GlobalBind(ctx.Handler,
+		event.GlobalBind(ctx,
 			mouse.Press, func(me *mouse.Event) event.Response {
 				// Left click to add a point to the curve
 				if me.Button == mouse.ButtonLeft {

--- a/examples/bezier/main.go
+++ b/examples/bezier/main.go
@@ -55,7 +55,7 @@ func main() {
 
 	oak.AddScene("bezier", scene.Scene{Start: func(ctx *scene.Context) {
 		mouseFloats := []float64{}
-		event.GlobalBind(ctx.EventHandler,
+		event.GlobalBind(ctx.Handler,
 			mouse.Press, func(me *mouse.Event) event.Response {
 				// Left click to add a point to the curve
 				if me.Button == mouse.ButtonLeft {

--- a/examples/click-propagation/main.go
+++ b/examples/click-propagation/main.go
@@ -46,30 +46,30 @@ func (hb *hoverButton) CID() event.CallerID {
 
 func newHoverButton(ctx *scene.Context, x, y, w, h float64, clr color.RGBA, layer int) {
 	hb := &hoverButton{}
-	hb.id = ctx.CallerMap.Register(hb)
+	hb.id = ctx.Register(hb)
 	hb.changingColorBox = newChangingColorBox(x, y, int(w), int(h), clr)
 
 	sp := collision.NewSpace(x, y, w, h, hb.id)
 	sp.SetZLayer(float64(layer))
 
 	mouse.Add(sp)
-	mouse.PhaseCollision(sp, ctx.EventHandler.GetCallerMap(), ctx.EventHandler)
+	mouse.PhaseCollision(sp, ctx.GetCallerMap(), ctx.Handler)
 
 	render.Draw(hb.changingColorBox, 0, layer)
 
-	event.Bind(ctx.EventHandler, mouse.Click, hb, func(box *hoverButton, me *mouse.Event) event.Response {
+	event.Bind(ctx.Handler, mouse.Click, hb, func(box *hoverButton, me *mouse.Event) event.Response {
 		fmt.Println(box, me.Point2)
 		box.changingColorBox.c = color.RGBA{128, 128, 128, 128}
 		me.StopPropagation = true
 		return 0
 	})
-	event.Bind(ctx.EventHandler, mouse.Start, hb, func(box *hoverButton, me *mouse.Event) event.Response {
+	event.Bind(ctx.Handler, mouse.Start, hb, func(box *hoverButton, me *mouse.Event) event.Response {
 		fmt.Println("start")
 		box.changingColorBox.c = color.RGBA{50, 50, 50, 50}
 		me.StopPropagation = true
 		return 0
 	})
-	event.Bind(ctx.EventHandler, mouse.Stop, hb, func(box *hoverButton, me *mouse.Event) event.Response {
+	event.Bind(ctx.Handler, mouse.Stop, hb, func(box *hoverButton, me *mouse.Event) event.Response {
 		fmt.Println("stop")
 		box.changingColorBox.c = clr
 		me.StopPropagation = true

--- a/examples/click-propagation/main.go
+++ b/examples/click-propagation/main.go
@@ -57,19 +57,19 @@ func newHoverButton(ctx *scene.Context, x, y, w, h float64, clr color.RGBA, laye
 
 	render.Draw(hb.changingColorBox, 0, layer)
 
-	event.Bind(ctx.Handler, mouse.Click, hb, func(box *hoverButton, me *mouse.Event) event.Response {
+	event.Bind(ctx, mouse.Click, hb, func(box *hoverButton, me *mouse.Event) event.Response {
 		fmt.Println(box, me.Point2)
 		box.changingColorBox.c = color.RGBA{128, 128, 128, 128}
 		me.StopPropagation = true
 		return 0
 	})
-	event.Bind(ctx.Handler, mouse.Start, hb, func(box *hoverButton, me *mouse.Event) event.Response {
+	event.Bind(ctx, mouse.Start, hb, func(box *hoverButton, me *mouse.Event) event.Response {
 		fmt.Println("start")
 		box.changingColorBox.c = color.RGBA{50, 50, 50, 50}
 		me.StopPropagation = true
 		return 0
 	})
-	event.Bind(ctx.Handler, mouse.Stop, hb, func(box *hoverButton, me *mouse.Event) event.Response {
+	event.Bind(ctx, mouse.Stop, hb, func(box *hoverButton, me *mouse.Event) event.Response {
 		fmt.Println("stop")
 		box.changingColorBox.c = clr
 		me.StopPropagation = true

--- a/examples/collision-demo/main.go
+++ b/examples/collision-demo/main.go
@@ -26,7 +26,7 @@ func main() {
 
 		collision.Attach(act.Vector, act.Space, nil, 0, 0)
 
-		event.Bind(ctx.Handler, event.Enter, act, func(act *AttachCollisionTest, ev event.EnterPayload) event.Response {
+		event.Bind(ctx, event.Enter, act, func(act *AttachCollisionTest, ev event.EnterPayload) event.Response {
 			if act.ShouldUpdate {
 				act.ShouldUpdate = false
 				act.R.Undraw()
@@ -57,7 +57,7 @@ func main() {
 
 		collision.PhaseCollision(act.Space, nil)
 
-		event.Bind(ctx.Handler, collision.Start, act, func(act *AttachCollisionTest, l collision.Label) event.Response {
+		event.Bind(ctx, collision.Start, act, func(act *AttachCollisionTest, l collision.Label) event.Response {
 			switch l {
 			case RED:
 				act.r += 125
@@ -75,7 +75,7 @@ func main() {
 			}
 			return 0
 		})
-		event.Bind(ctx.Handler, collision.Stop, act, func(act *AttachCollisionTest, l collision.Label) event.Response {
+		event.Bind(ctx, collision.Stop, act, func(act *AttachCollisionTest, l collision.Label) event.Response {
 			switch l {
 			case RED:
 				act.r -= 125

--- a/examples/collision-demo/main.go
+++ b/examples/collision-demo/main.go
@@ -26,7 +26,7 @@ func main() {
 
 		collision.Attach(act.Vector, act.Space, nil, 0, 0)
 
-		event.Bind(ctx.EventHandler, event.Enter, act, func(act *AttachCollisionTest, ev event.EnterPayload) event.Response {
+		event.Bind(ctx.Handler, event.Enter, act, func(act *AttachCollisionTest, ev event.EnterPayload) event.Response {
 			if act.ShouldUpdate {
 				act.ShouldUpdate = false
 				act.R.Undraw()
@@ -57,7 +57,7 @@ func main() {
 
 		collision.PhaseCollision(act.Space, nil)
 
-		event.Bind(ctx.EventHandler, collision.Start, act, func(act *AttachCollisionTest, l collision.Label) event.Response {
+		event.Bind(ctx.Handler, collision.Start, act, func(act *AttachCollisionTest, l collision.Label) event.Response {
 			switch l {
 			case RED:
 				act.r += 125
@@ -75,7 +75,7 @@ func main() {
 			}
 			return 0
 		})
-		event.Bind(ctx.EventHandler, collision.Stop, act, func(act *AttachCollisionTest, l collision.Label) event.Response {
+		event.Bind(ctx.Handler, collision.Stop, act, func(act *AttachCollisionTest, l collision.Label) event.Response {
 			switch l {
 			case RED:
 				act.r -= 125

--- a/examples/custom-cursor/main.go
+++ b/examples/custom-cursor/main.go
@@ -37,7 +37,7 @@ func main() {
 			)
 			ctx.DrawStack.Draw(box)
 
-			ctx.EventHandler.GlobalBind(mouse.Drag, func(_ event.CallerID, me interface{}) int {
+			ctx.Handler.GlobalBind(mouse.Drag, func(_ event.CallerID, me interface{}) int {
 				mouseEvent := me.(*mouse.Event)
 				box.SetPos(mouseEvent.X(), mouseEvent.Y())
 				return 0

--- a/examples/joystick-viz/main.go
+++ b/examples/joystick-viz/main.go
@@ -22,7 +22,7 @@ func main() {
 		*latestInput = "Latest Input: Keyboard+Mouse"
 		ctx.DrawStack.Draw(render.NewStrPtrText(latestInput, 10, 460), 4)
 		ctx.DrawStack.Draw(render.NewText("Space to Vibrate", 10, 440), 4)
-		ctx.EventHandler.GlobalBind(event.InputChange, func(_ event.CallerID, payload interface{}) int {
+		ctx.Handler.GlobalBind(event.InputChange, func(_ event.CallerID, payload interface{}) int {
 			input := payload.(oak.InputType)
 			switch input {
 			case oak.InputJoystick:

--- a/examples/multi-window/main.go
+++ b/examples/multi-window/main.go
@@ -26,7 +26,7 @@ func main() {
 			ctx.DrawStack.Draw(cb, 0)
 			dFPS := render.NewDrawFPS(0.1, nil, 600, 10)
 			ctx.DrawStack.Draw(dFPS, 1)
-			ctx.EventHandler.GlobalBind(mouse.Press, mouse.Binding(func(_ event.CallerID, me *mouse.Event) int {
+			ctx.Handler.GlobalBind(mouse.Press, mouse.Binding(func(_ event.CallerID, me *mouse.Event) int {
 				cb.SetPos(me.X(), me.Y())
 				return 0
 			}))
@@ -55,7 +55,7 @@ func main() {
 			ctx.DrawStack.Draw(cb, 0)
 			dFPS := render.NewDrawFPS(0.1, nil, 600, 10)
 			ctx.DrawStack.Draw(dFPS, 1)
-			ctx.EventHandler.GlobalBind(mouse.Press, mouse.Binding(func(_ event.CallerID, me *mouse.Event) int {
+			ctx.Handler.GlobalBind(mouse.Press, mouse.Binding(func(_ event.CallerID, me *mouse.Event) int {
 				cb.SetPos(me.X(), me.Y())
 				return 0
 			}))

--- a/examples/pong/main.go
+++ b/examples/pong/main.go
@@ -41,7 +41,7 @@ func main() {
 func newBall(ctx *scene.Context, x, y float64) {
 	b := entities.NewMoving(x, y, 10, 10, render.NewColorBoxR(10, 10, color.RGBA{255, 255, 255, 255}), nil, 0, 0)
 	render.Draw(b.R, 2)
-	event.GlobalBind(ctx.EventHandler, event.Enter, func(_ event.EnterPayload) event.Response {
+	event.GlobalBind(ctx.Handler, event.Enter, func(_ event.EnterPayload) event.Response {
 		if b.Delta.X() == 0 && b.Delta.Y() == 0 {
 			b.Delta.SetY((rand.Float64() - 0.5) * 4)
 			b.Delta.SetX((rand.Float64() - 0.5) * 16)
@@ -76,9 +76,9 @@ func newPaddle(ctx *scene.Context, x, y float64, player int) {
 	render.Draw(p.R, 1)
 	p.Space.UpdateLabel(hitPaddle)
 	if player == 1 {
-		event.Bind(ctx.EventHandler, event.Enter, p, enterPaddle(key.UpArrow, key.DownArrow))
+		event.Bind(ctx.Handler, event.Enter, p, enterPaddle(key.UpArrow, key.DownArrow))
 	} else {
-		event.Bind(ctx.EventHandler, event.Enter, p, enterPaddle(key.W, key.S))
+		event.Bind(ctx.Handler, event.Enter, p, enterPaddle(key.W, key.S))
 	}
 }
 

--- a/examples/pong/main.go
+++ b/examples/pong/main.go
@@ -41,7 +41,7 @@ func main() {
 func newBall(ctx *scene.Context, x, y float64) {
 	b := entities.NewMoving(x, y, 10, 10, render.NewColorBoxR(10, 10, color.RGBA{255, 255, 255, 255}), nil, 0, 0)
 	render.Draw(b.R, 2)
-	event.GlobalBind(ctx.Handler, event.Enter, func(_ event.EnterPayload) event.Response {
+	event.GlobalBind(ctx, event.Enter, func(_ event.EnterPayload) event.Response {
 		if b.Delta.X() == 0 && b.Delta.Y() == 0 {
 			b.Delta.SetY((rand.Float64() - 0.5) * 4)
 			b.Delta.SetX((rand.Float64() - 0.5) * 16)
@@ -76,9 +76,9 @@ func newPaddle(ctx *scene.Context, x, y float64, player int) {
 	render.Draw(p.R, 1)
 	p.Space.UpdateLabel(hitPaddle)
 	if player == 1 {
-		event.Bind(ctx.Handler, event.Enter, p, enterPaddle(key.UpArrow, key.DownArrow))
+		event.Bind(ctx, event.Enter, p, enterPaddle(key.UpArrow, key.DownArrow))
 	} else {
-		event.Bind(ctx.Handler, event.Enter, p, enterPaddle(key.W, key.S))
+		event.Bind(ctx, event.Enter, p, enterPaddle(key.W, key.S))
 	}
 }
 

--- a/scene/context.go
+++ b/scene/context.go
@@ -15,18 +15,19 @@ import (
 // and a reference to the OS window itself. When a scene ends, modifications made
 // to these structures will be reset, excluding window modifications.
 // TODO oak v4: consider embedding these system objects on the context to change
-// ctx.DrawStack.Draw to ctx.Draw and ctx.EventHandler.Bind to ctx.Bind
+// ctx.DrawStack.Draw to ctx.Draw and ctx.Handler.Bind to ctx.Bind
 type Context struct {
 	// This context will be canceled when the scene ends
 	context.Context
 
+	*event.CallerMap
+	event.Handler
 	PreviousScene string
 	SceneInput    interface{}
 	Window        window.Window
 
-	DrawStack     *render.DrawStack
-	EventHandler  event.Handler
-	CallerMap     *event.CallerMap
+	DrawStack *render.DrawStack
+
 	MouseTree     *collision.Tree
 	CollisionTree *collision.Tree
 	KeyState      *key.State

--- a/sceneLoop.go
+++ b/sceneLoop.go
@@ -74,7 +74,7 @@ func (w *Window) sceneLoop(first string, trackingInputs, batchLoad bool) {
 				PreviousScene: prevScene,
 				SceneInput:    result.NextSceneInput,
 				DrawStack:     w.DrawStack,
-				EventHandler:  w.eventHandler,
+				Handler:       w.eventHandler,
 				CallerMap:     w.CallerMap,
 				MouseTree:     w.MouseTree,
 				CollisionTree: w.CollisionTree,

--- a/sceneLoop.go
+++ b/sceneLoop.go
@@ -129,7 +129,7 @@ func (w *Window) sceneLoop(first string, trackingInputs, batchLoad bool) {
 		// be triggered and attempt to access an entity
 		w.CollisionTree.Clear()
 		w.MouseTree.Clear()
-		w.CallerMap.Reset()
+		w.CallerMap.Clear()
 		w.eventHandler.SetCallerMap(w.CallerMap)
 		w.DrawStack.Clear()
 		w.DrawStack.PreDraw()


### PR DESCRIPTION
Not sold on this but its the only shortening of methods that seems even slightly reasonable. Unfortunately creating helper functions around the context with it still working on the generic functions doesnt work and the embedded interface doesnt allow for this to be passwed as an eventhandler to binds. So definitely not ideal and we refer to it as ctx.Handler rather than ctx.EventHandler which while shorter seems less descriptive.

The bonus of course is signature for callermap interactions so one can call things like  ctx.Register(entity)

Thoughts?