### PR TITLE
event/internal: Unbind calls now take the current reset of the bus

### DIFF
--- a/event/internal.go
+++ b/event/internal.go
@@ -36,7 +36,7 @@ func (bus *Bus) trigger(binds bindableList, eventID UnsafeEventID, callerID Call
 					// A: This goroutine does not own a write lock on the bus, and should therefore
 					//    not modify its contents. We do not have a simple way of promoting our read lock
 					//    to a write lock.
-					bus.Unbind(Binding{EventID: eventID, CallerID: callerID, BindID: bindID})
+					bus.Unbind(Binding{EventID: eventID, CallerID: callerID, BindID: bindID, busResetCount: bus.resetCount})
 				case ResponseUnbindThisCaller:
 					bus.UnbindAllFrom(callerID)
 				}

--- a/event/response_test.go
+++ b/event/response_test.go
@@ -12,6 +12,9 @@ func TestBindingResponses(t *testing.T) {
 	t.Run("UnbindThisBinding", func(t *testing.T) {
 		b := event.NewBus(event.NewCallerMap())
 
+		// bus reset counts are checked against bindings
+		b.Reset()
+
 		var calls int32
 		b1 := b.UnsafeBind(1, 0, func(ci event.CallerID, h event.Handler, i interface{}) event.Response {
 			atomic.AddInt32(&calls, 1)


### PR DESCRIPTION
When returning unbindthisbind we previously did not take into account the bus reset count.
Now we will succesfully remove the bind as long as the bus has not already been reset between the unbind call and unbind's go channel's resolution.