### PR TITLE
render/font: Enforce default truetype font height for Height()

### DIFF
--- a/render/font.go
+++ b/render/font.go
@@ -29,6 +29,8 @@ var (
 	// DefaultFontGenerator is a default font generator, using an internally
 	// compiled font colored white by default.
 	DefaultFontGenerator = DefFontGenerator
+
+	defFontSize = 12.0
 )
 
 // A Font can create text renderables. It should be constructed from
@@ -100,7 +102,7 @@ func (fg *FontGenerator) Generate() (*Font, error) {
 	}
 
 	// This logic is copied from truetype for their face scaling
-	size := 12.0
+	size := defFontSize
 	if fg.FontOptions.Size != 0 {
 		size = fg.FontOptions.Size
 	}
@@ -217,6 +219,9 @@ func (f *Font) drawString(s string) {
 
 // Height returns the height or size of the font
 func (f *Font) Height() float64 {
+	if f.gen.Size == 0 {
+		return defFontSize
+	}
 	return f.gen.Size
 }
 

--- a/render/font_test.go
+++ b/render/font_test.go
@@ -120,6 +120,19 @@ func TestFont_Height(t *testing.T) {
 	if f.Height() != ht {
 		t.Fatalf("size did not match height: got %v expected %v", f.Height(), ht)
 	}
+
+	fgEmpty := FontGenerator{
+		File:  "testdata/assets/fonts/luxisr.ttf",
+		Color: image.NewUniform(color.RGBA{255, 0, 0, 255}),
+	}
+	f, err = fgEmpty.Generate()
+	if err != nil {
+		t.Fatalf("generate failed: %v", err)
+	}
+	if f.Height() != defFontSize {
+		t.Fatalf("size did not match height: got %v expected %v", f.Height(), ht)
+	}
+
 }
 
 func TestFont_RegenerateWith(t *testing.T) {


### PR DESCRIPTION
Currently when a font is generated from a fontgenerator that has fontsize as 0 it will overwrite it with the value of 12 (as per truetype).
However the height method on a font calls the gen referenced(which is a pointer so could change which is interesting in and of itself). At font generation time the size change is only set on the font itself rather than the generator so we return a 0 instead of a 12 prior to this change.

