### PR TITLE
audio: fix imports for unsupported writers

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -66,7 +66,7 @@ jobs:
       run: ./test_examples.sh
 
   test-js-compilation:
-    name: Test (linux x64)
+    name: Test Examples (JS Compilation)
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -65,6 +65,27 @@ jobs:
     - name: Test
       run: ./test_examples.sh
 
+  test-js-compilation:
+    name: Test (linux x64)
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Set up Go 1.18
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.18
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
+
+      - name: Test
+        run: ./test_examples_js.sh
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/audio/writer_other.go
+++ b/audio/writer_other.go
@@ -2,7 +2,10 @@
 
 package audio
 
-import "github.com/oakmound/oak/v4/oakerr"
+import (
+	"github.com/oakmound/oak/v4/audio/pcm"
+	"github.com/oakmound/oak/v4/oakerr"
+)
 
 func initOS(driver Driver) error {
 	return oakerr.UnsupportedPlatform{
@@ -10,7 +13,7 @@ func initOS(driver Driver) error {
 	}
 }
 
-func newWriter(f Format) (Writer, error) {
+func newWriter(f pcm.Format) (pcm.Writer, error) {
 	return nil, oakerr.UnsupportedPlatform{
 		Operation: "pcm.NewWriter",
 	}

--- a/shake/shake.go
+++ b/shake/shake.go
@@ -108,7 +108,7 @@ func (sk *Shaker) ShakeContext(ctx context.Context, sp ShiftPoser, dur time.Dura
 }
 
 type screenToPoser struct {
-	window.Window
+	window.App
 }
 
 func (stp screenToPoser) ShiftPos(x, y float64) {

--- a/test_examples_js.sh
+++ b/test_examples_js.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+
+examples=$(find ./examples | grep main.go$)
+root=$(pwd)
+for ex in $examples
+do
+    echo "$ex"
+    dir=$(dirname "$ex")
+    # excluded because screenopts explicitly demonstrates
+    # desktop-specific features
+    if [[ "$dir" == "./examples/screenopts" ]]; then
+      continue
+    fi
+    # excluded because text includes a find-font dependency
+    # that does not compile in js
+    if [[ "$dir" == "./examples/text" ]]; then
+      continue
+    fi
+    cd "$dir"
+    GOOS=js GOARCH=wasm go build .
+    cd "$root"
+done


### PR DESCRIPTION
This fixes a compilation error when building the `audio` package for non-windows/linux/darwin targets. 

Pending before merge: 
- [x] Trivial 'does this compile' tests for js for all examples. 