### PR TITLE
entities/x: Allow actual metadata usage

### DIFF
--- a/entities/entity.go
+++ b/entities/entity.go
@@ -244,6 +244,7 @@ func New(ctx *scene.Context, opts ...Option) *Entity {
 		Renderable: g.Renderable,
 		Speed:      g.Speed,
 		Children:   children,
+		metadata:   map[string]string{},
 	}
 
 	if g.Renderable == nil && g.Color != nil {


### PR DESCRIPTION
Entities have a concept of metadata which is an unexported map.
This is a pretty cool feature and we've used it via unreleased branches before.

However since it is un-exported and uninitialized anyone who does not reimplement accessors on some wrapping class cannot use it.

In this PR we look to change that by allowing initialization of the map by default on entity creation.


To reproduce take an entity such as the one in platformer example https://github.com/oakmound/oak/blob/v4.1.0/examples/platformer/main.go#L28

`		char := entities.New(ctx,
			entities.WithRect(floatgeom.NewRect2WH(100, 100, 16, 32)),
			entities.WithColor(color.RGBA{255, 0, 0, 255}),
			entities.WithSpeed(floatgeom.Point2{3, 7}),
		)
`

then try to set some metadata
`		char.SetMetadata("mykey", "somevalue")

`